### PR TITLE
Make (scalar) MX constants print as numbers

### DIFF
--- a/symbolic/mx/constant_mx.hpp
+++ b/symbolic/mx/constant_mx.hpp
@@ -320,10 +320,10 @@ namespace CasADi{
 
   template<typename Value>
   void Constant<Value>::printPart(std::ostream &stream, int part) const{
-    stream << "Const<" << v_.value << ">(";
     if(sparsity().scalar(true)){
-      stream << "scalar";
+      stream << v_.value;
     } else {
+      stream << "Const<" << v_.value << ">(";
       stream << size1() << "x" << size2() << ": ";
       if(sparsity().dense()){
         stream << "dense";
@@ -334,8 +334,8 @@ namespace CasADi{
       } else {
         stream << double(size())/sparsity().numel()*100 << " %";
       }        
+      stream << ")";
     }
-    stream << ")";
   }
 
 } // namespace CasADi


### PR DESCRIPTION
Currently, constants in MX expressions print as e.g. `Const<5>(scalar)`:

```
In [1]: from casadi import *

In [2]: 5*MX('x')
Out[2]: MX((Const<5>(scalar)*x))
```

I want to request that constants be printed just as literals instead, e.g. `5`. The current format is scaring our users.

This patch changes printing of scalar MX constants, which would go a long way for us. Whether you want to take the patch or not, I hope that you can take this as a request to simplify printing of constants in MX expressions.
