### PR TITLE
First attempt to make CasADi usable as a dependency for external SWIG modules

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -137,6 +137,7 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR}/..)
 link_directories (${CMAKE_CURRENT_SOURCE_DIR}/../build/lib)
 
 set(CASADI_SWIG_FLAGS ${CASADI_SWIG_FLAGS} "-I${CMAKE_CURRENT_SOURCE_DIR}/swig_lib")
+set(CASADI_SWIG_FLAGS ${CASADI_SWIG_FLAGS} "-DCASADI_MODULE")
   
 # set the global swig flags to empty
 # set(CMAKE_SWIG_FLAGS "-outdir ${PROJECT_BINARY_DIR}")

--- a/swig/common.i
+++ b/swig/common.i
@@ -207,6 +207,7 @@ class pair {};
 %include "symbolic/casadi_options.hpp"
 %include "symbolic/casadi_meta.hpp"
 
+#ifdef CASADI_MODULE
 %{
 #define START \
   if (CasADi::CasadiOptions::catch_errors_python){ \
@@ -251,6 +252,7 @@ class pair {};
     SWIG_exception(SWIG_TypeError, e); \
   }
 }
+#endif // CASADI_MODULE
 
 #ifdef SWIGPYTHON
 #ifndef WITH_NUMPY

--- a/swig/commontypemaps.i
+++ b/swig/commontypemaps.i
@@ -91,6 +91,7 @@
 %template() std::vector< std::vector<std::vector<CasADi::SX> > > ;
 #endif //SWIG_MAIN_MODULE
 
+#ifdef CASADI_MODULE
 #ifdef SWIGPYTHON
 %typemap(in) int (int m) {
   bool result=meta< int >::as($input,m);
@@ -116,6 +117,7 @@
 %typemap(freearg) double {}
 
 #endif //SWIGPYTHON
+#endif // CASADI_MODULE
 
 #ifdef SWIGPYTHON
 %typemap(out) CasADi::GenericType {
@@ -144,8 +146,10 @@ if (!ret) {
 %my_generic_const_typemap(SWIG_TYPECHECK_DOUBLE,double);
 #endif // SWIGPYTHON
 
+#ifdef CASADI_MODULE
 %my_generic_const_typemap(PRECEDENCE_DVector,std::vector<double>);
 %my_generic_const_typemap(PRECEDENCE_IVector,std::vector<int>);
+#endif // CASADI_MODULE
 
 %my_generic_const_typemap(PRECEDENCE_SX,CasADi::SX);
 %my_generic_const_typemap(PRECEDENCE_SXVector,std::vector< CasADi::SX >);
@@ -193,8 +197,12 @@ if (!ret) {
 #ifdef SWIGPYTHON
 %outputRefOwn(CasADi::CRSSparsity)
 %outputRefOwn(std::vector< CasADi::SX >)
+
+#ifdef CASADI_MODULE
 %outputRefOwn(std::vector< int >)
 %outputRefOwn(std::vector< double >)
+#endif // CASADI_MODULE
+
 %outputRefOwn(CasADi::Matrix< double >)
 %outputRefOwn(CasADi::Matrix< CasADi::SX >)
 #endif // SWIGPYTHON


### PR DESCRIPTION
When doing `%import "casadi.i"`, some things follow along that probably shouldn't.
This patch
- Adds a define `-DCASADI_MODULE` in `swig/CMakeLists.txt` that is in effect when CasADi builds its SWIG wrappers, but should not be defined in other modules.
- Adds `#ifdef CASADI_MODULE` to exclude a few things when in another module:
  - Typemaps on non-CasADi types: `int, double, vector<int>, vector<double>`
  - `%exception` directives: they depend on a CasADi-internal flag, define macros `START` and `STOP` that are likely to conflict with existing symbols, and also depend on `exception.i`.

With this patch, I am able to create a standalone SWIG module for my code that uses the CasADi SWIG module as a dependency through `casadi.i`. I hope that either it can be accepted, or changes can be made to the same effect.

Note: Additionally, when using `%import "casadi"` in another module, standard includes like `std_vector.i` and `exception.i` that should be included in the module must be included before `%import "casadi"`, since their inclusion from within the imported `casadi.i` will otherwise cause them to be imported instead.
