### PR TITLE
Add link dependencies for casadi_ipopt_interface so that it can build as a dll on windows

### DIFF
--- a/interfaces/ipopt/CMakeLists.txt
+++ b/interfaces/ipopt/CMakeLists.txt
@@ -24,6 +24,9 @@ add_library(casadi_ipopt_interface STATIC ${IPOPT_INTERFACE_SRCS})
 endif(ENABLE_STATIC)
 if(ENABLE_SHARED)
 add_library(casadi_ipopt_interface SHARED ${IPOPT_INTERFACE_SRCS})
+if(NOT ENABLE_STATIC)
+target_link_libraries(casadi_ipopt_interface casadi ${IPOPT_LIBRARIES})
+endif(NOT ENABLE_STATIC)
 endif(ENABLE_SHARED)
 install(TARGETS casadi_ipopt_interface
   LIBRARY DESTINATION lib


### PR DESCRIPTION
This is a follow-up to #847. It adds linker dependencies for `casadi_ipopt_interface` so that it too can be built as a dll on windows.
