### PR TITLE
Expose more GenericType constructors in SWIG interface

### DIFF
--- a/symbolic/generic_type.hpp
+++ b/symbolic/generic_type.hpp
@@ -40,7 +40,7 @@ namespace CasADi{
   class GenericType : public SharedObject{
     public:
     GenericType();
-    #ifndef SWIG
+    #if !((defined SWIG) && ((defined SWIGPYTHON) || (defined SWIGOCTAVE)))
     GenericType(bool b);
     GenericType(int i);
     GenericType(double d);


### PR DESCRIPTION
This pull request exposes more of the `GenericType` constructors when wrapping CasADi to other languagues than python and octave, using SWIG.

The reason that I hope that we can do something like this is that we need the `GenericType(const std::string& s);` constructor to be able to name an `MXFunction` when creating it from java, for which we have made a minimal CasADi wrapper that exposes the functionality that we need.

I'm not sure why the original `#ifndef SWIG` is there in the first place, so I'm not sure what is the best way to expose what we need. The current patch is at least rather simple, and does not change the behavior of CasADi with the SWIG interfaces it is currently bundled with.
