### PR TITLE
Fixes #899: Issue in scalar-matrix MX operation

### DIFF
--- a/symbolic/mx/mx_node.cpp
+++ b/symbolic/mx/mx_node.cpp
@@ -518,7 +518,8 @@ namespace CasADi{
   }
 
   MX MXNode::getBinary(int op, const MX& y, bool scX, bool scY) const{
-  
+    casadi_assert(sparsity()==y.sparsity() || scX || scY);
+    
     if (CasadiOptions::simplification_on_the_fly) {
     
       // If identically zero due to one argumebt being zero
@@ -565,7 +566,7 @@ namespace CasADi{
             break;
           case OP_ADD:
           case OP_SUB:
-            if(y->isZero()) return shared_from_this<MX>();
+            if(y->isZero()) return scX ? MX(y.size1(),y.size2(),shared_from_this<MX>()) : shared_from_this<MX>();
             break;
           case OP_MUL:
             if(y->isValue(1)) return shared_from_this<MX>();

--- a/test/python/mx.py
+++ b/test/python/mx.py
@@ -2290,7 +2290,6 @@ class MXtests(casadiTestCase):
     with self.assertRaises(RuntimeError):
       d = x / c
       
-  @known_bug()
   @memory_heavy()
   def test_MX_shapes(self):
       self.message("MX unary operations")
@@ -2365,7 +2364,6 @@ class MXtests(casadiTestCase):
                 if sp.size()>0 and sp2.size()>0 and v1!=0 and v2!=0:
                   self.checkfx(f,g,hessian=False,failmessage=str([sp,sp2,v1,v2,x1_,x2_,name]))
 
-  @known_bug()
   @memory_heavy()
   def test_MXConstant(self):
       self.message("MX unary operations, constant")


### PR DESCRIPTION
An alternative fix for #899.
Special care was taken that sparsities are never needlessly lost.
Passes all tests added in 8b098c1

Also fixes #897

(See also #900)
