### PR TITLE
Exclude all typemaps in commontypemaps.i when used in a separate SWIG module

### DIFF
--- a/swig/commontypemaps.i
+++ b/swig/commontypemaps.i
@@ -121,7 +121,6 @@
 %typemap(freearg) double {}
 
 #endif //SWIGPYTHON
-#endif // CASADI_MODULE
 
 #ifdef SWIGPYTHON
 %typemap(out) CasADi::GenericType {
@@ -157,10 +156,8 @@ if (!ret) {
 %my_generic_const_typemap(SWIG_TYPECHECK_DOUBLE,double);
 #endif // SWIGPYTHON
 
-#ifdef CASADI_MODULE
 %my_generic_const_typemap(PRECEDENCE_DVector,std::vector<double>);
 %my_generic_const_typemap(PRECEDENCE_IVector,std::vector<int>);
-#endif // CASADI_MODULE
 
 %my_generic_const_typemap(PRECEDENCE_SX,CasADi::SX);
 %my_generic_const_typemap(PRECEDENCE_SXVector,std::vector< CasADi::SX >);
@@ -210,11 +207,10 @@ if (!ret) {
 %outputRefOwn(CasADi::CRSSparsity)
 %outputRefOwn(std::vector< CasADi::SX >)
 
-#ifdef CASADI_MODULE
 %outputRefOwn(std::vector< int >)
 %outputRefOwn(std::vector< double >)
-#endif // CASADI_MODULE
 
 %outputRefOwn(CasADi::Matrix< double >)
 %outputRefOwn(CasADi::Matrix< CasADi::SX >)
+#endif // CASADI_MODULE
 #endif // SWIGPYTHON


### PR DESCRIPTION
This is a follow-up to #861.
Most of the typemaps applied in `commontypemaps.i` make use of CasADi's `meta` class.
Until is known if/how separate SWIG modules should deal with this, (see [this discussion](https://groups.google.com/forum/?fromgroups=#!topic/casadi-users/PaNcnIUyvYs)), they need to be disabled in order that CasADi can be used from other SWIG modules. The reason that I submit this pull request is because one of those typemaps (on `vector<MX>`) is giving me trouble.

This patch disables all typemaps in `commontypemaps.i`. The ones that do not use `meta`, but are also disabled, are:
- `%my_value_output_typemaps(...);` - These allow to use output arguments named `OUTPUT` that are mapped by SWIG into return values. I think that it should be up to the writer of the external SWIG module if they want to use this feature, but I also think that it would be ok to leave them in if that is deemed more appropriate.
- `%my_creator_typemap(PRECEDENCE_CREATOR, CasADi::implicitFunctionCreator);` - I'm not sure what this does. Perhaps there is a reason to keep it also for external SWIG modules? I don't think that I'll be passing `CasADi::implicitFunctionCreator` objects using SWIG anytime soon, so it's either way to me.

What do you think? Does this seem reasonable? Any thoughts on the last two points?
