### PR TITLE
Add link dependencies for casadi_ipopt_interface so that it can build as a dll (new attempt at #864)

### DIFF
--- a/interfaces/ipopt/CMakeLists.txt
+++ b/interfaces/ipopt/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(casadi_ipopt_interface STATIC ${IPOPT_INTERFACE_SRCS})
 endif(ENABLE_STATIC)
 if(ENABLE_SHARED)
 add_library(casadi_ipopt_interface SHARED ${IPOPT_INTERFACE_SRCS})
+target_link_libraries(casadi_ipopt_interface casadi ${IPOPT_LIBRARIES})
 endif(ENABLE_SHARED)
 install(TARGETS casadi_ipopt_interface
   LIBRARY DESTINATION lib


### PR DESCRIPTION
It appears that there was a mistake when #864 was merged, probably because I force-pushed my topic branch while @jaeandersson thought that I had added another commit. #864 was merged in https://github.com/casadi/casadi/commit/ffc239b0cff1a598bb483d135cf61a6bc8252903, and just after reverted in https://github.com/casadi/casadi/commit/3aeb551133dd5e19e011116539d6efea076b5145, resulting in no net change. I believe that this PR contains the actual desired end result.
