### PR TITLE
Don't install .svn directories in casadi/tools/

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -346,6 +346,7 @@ The idea is to supply a directory that python knows about (included in PYTHONPAT
     COMPONENT install_python
     USE_SOURCE_PERMISSIONS
     PATTERN .pyc EXCLUDE
+    PATTERN .svn EXCLUDE
   )
   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/python/__init__.py
     DESTINATION ${PYTHON_PREFIX}/casadi


### PR DESCRIPTION
Some of my colleagues have been getting problems recently where `.svn` directories are installed into `casadi/tools/` and `casadi/tools/graph`. This patch seems to fix them. (This then gives permissions violations when we try to copy the installation into a new location.)
