### PR TITLE
bug?

### DIFF
--- a/symbolic/fx/x_function_internal.hpp
+++ b/symbolic/fx/x_function_internal.hpp
@@ -581,7 +581,7 @@ namespace CasADi{
   
     // Get a bidirectional partition
     CRSSparsity D1, D2;
-    getPartition(iind,oind,D1,D2,true,symmetric);
+    getPartition(iind,oind,D1,D2,compact,symmetric);
     if(verbose()) std::cout << "XFunctionInternal::jac graph coloring completed" << std::endl;
 
     // Get the number of forward and adjoint sweeps
@@ -602,7 +602,7 @@ namespace CasADi{
     std::vector<std::vector<MatType> > fseed, aseed, fsens, asens;
   
     // Get the sparsity of the Jacobian block
-    const CRSSparsity& jsp = jacSparsity(iind,oind,true,symmetric);
+    const CRSSparsity& jsp = jacSparsity(iind,oind,compact,symmetric);
     const std::vector<int>& jsp_rowind = jsp.rowind();
     const std::vector<int>& jsp_col = jsp.col();
   

--- a/symbolic/matrix/crs_sparsity_internal.cpp
+++ b/symbolic/matrix/crs_sparsity_internal.cpp
@@ -2925,6 +2925,7 @@ namespace CasADi{
   }
   
   CRSSparsity CRSSparsityInternal::starColoring2(int ordering, int cutoff) const{
+    casadi_assert(ncol_==nrow_);
     
     // TODO What we need here, is a distance-2 smallest last ordering
     // Reorder, if necessary
@@ -3176,6 +3177,8 @@ namespace CasADi{
   
 
   CRSSparsity CRSSparsityInternal::starColoring(int ordering, int cutoff) const{
+    casadi_assert(ncol_==nrow_);
+  
     // Reorder, if necessary
     if(ordering!=0){
       casadi_assert(ordering==1);


### PR DESCRIPTION
Something seems to be out of order here.
If symmetric=true, the input(iind) dense and the output(oind) sparse, `getPartition(iind,oind,D1,D2,true,symmetric);` would try to do a starcoloring of a rectangular matrix.

Possibly, the attempted fix is wrong, but the current implementation is wrong as well.
