### PR TITLE
FunctionInternal::generateCode now writes to a stream, not a file

### DIFF
--- a/symbolic/function/function.cpp
+++ b/symbolic/function/function.cpp
@@ -277,7 +277,20 @@ namespace CasADi{
   }
 
   void Function::generateCode(const string& filename){
-    (*this)->generateCode(filename);
+    std::ofstream cfile;
+    cfile.open (filename.c_str());
+    generateCode(cfile);
+    cfile.close();
+  }
+
+  std::string Function::generateCode(){
+    std::ostringstream cfile;
+    generateCode(cfile);
+    return cfile.str();
+  }
+
+  void Function::generateCode(std::ostream &stream){
+    (*this)->generateCode(stream);
   }
 
   const IOScheme& Function::inputScheme() const{

--- a/symbolic/function/function.hpp
+++ b/symbolic/function/function.hpp
@@ -330,6 +330,12 @@ namespace CasADi{
     
     /** \brief Export / Generate C code for the function */
     void generateCode(const std::string& filename);
+
+    /** \brief Generate C code for the function */
+    std::string generateCode();
+
+    /** \brief Generate C code for the function */
+    void generateCode(std::ostream& filename);
     
     /// \cond INTERNAL
     /** \brief  Access functions of the node */

--- a/symbolic/function/function_internal.cpp
+++ b/symbolic/function/function_internal.cpp
@@ -1996,12 +1996,10 @@ namespace CasADi{
 
   }
     
-  void FunctionInternal::generateCode(const string& src_name){
+  void FunctionInternal::generateCode(std::ostream &cfile){
     assertInit();
     
-    // Create the c source file
-    std::ofstream cfile;
-    cfile.open (src_name.c_str());
+    // set stream parameters
     cfile.precision(std::numeric_limits<double>::digits10+2);
     cfile << std::scientific; // This is really only to force a decimal dot, would be better if it can be avoided
 
@@ -2106,10 +2104,6 @@ namespace CasADi{
       cfile << "  return 0;" << std::endl;
       cfile << "}" << std::endl << std::endl;
     }
-
-
-    // Close the results file
-    cfile.close();
   }
 
   void FunctionInternal::generateFunction(std::ostream &stream, const std::string& fname, const std::string& input_type, const std::string& output_type, const std::string& type, CodeGenerator& gen) const{

--- a/symbolic/function/function_internal.hpp
+++ b/symbolic/function/function_internal.hpp
@@ -187,8 +187,8 @@ namespace CasADi{
     */
     MXFunction wrapMXFunction();
 
-    /** \brief  Print to a c file */
-    virtual void generateCode(const std::string& filename);
+    /** \brief  Print to a stream */
+    virtual void generateCode(std::ostream &cfile);
 
     /** \brief Generate code for function inputs and outputs */
     void generateIO(CodeGenerator& gen);


### PR DESCRIPTION
Function::generateCode is overloaded to keep the old functionality, but it can now return a string directly
