### PR TITLE
Fixes to make CasADi importable from external SWIG modules again

### DIFF
--- a/swig/casadi_core.i
+++ b/swig/casadi_core.i
@@ -20,7 +20,7 @@
  *
  */
 
-%module casadi_core
+%module(package="casadi") casadi_core
 
 //  The things needed to make each casadi_*.i  compilable by itself: typemaps
 %include "common.i"

--- a/swig/casadi_noncore.i
+++ b/swig/casadi_noncore.i
@@ -20,7 +20,7 @@
  *
  */
 
-%module casadi_noncore
+%module(package="casadi") casadi_noncore
 
 %include "common.i"
 

--- a/swig/casadi_slicot_interface.i
+++ b/swig/casadi_slicot_interface.i
@@ -20,7 +20,7 @@
  *
  */
 
-%module casadi_slicot_interface
+%module(package="casadi") casadi_slicot_interface
 
 %include "common.i"
 

--- a/swig/common.i
+++ b/swig/common.i
@@ -690,6 +690,7 @@ using namespace casadi;
 
 %}
 
+#ifdef CASADI_MODULE
 #ifndef SWIGXML
 %traits_swigtype(casadi::DerivativeGenerator);
 %fragment(SWIG_Traits_frag(casadi::DerivativeGenerator));
@@ -705,6 +706,7 @@ using namespace casadi;
 %traits_swigtype(casadi::Function);
 %fragment(SWIG_Traits_frag(casadi::Function));
 
+#endif
 #endif
 
 


### PR DESCRIPTION
It seems that the step from CasADi 1.8 to 2.0 has introduced a few problems for using CasADi's SWIG files from external SWIG modules, which this PR attempts to fix:
- Wrap some traits/fragments with `#idef CASADI_MODULE` to avoid leakage into
  code that SWIG generates for other modules.
- Specify the package of all CasADi modules since they now reside in the
  `casadi` package in Python. Otherwise, e.g. `%import "casadi_core.i"` will
  always emit an unqualified `import casadi_core` line into the generated
  Python wrappers. Now it becomes `import casadi.casadi_core` instead.

With these changes, I'm once again able to use CasADi's SWIG files (`%import casadi_core.i`) in our own SWIG module.
