### PR TITLE
#define ALLOW_ALL_OPTIONS

### DIFF
--- a/casadi/interfaces/qpoases/qpoases_interface.cpp
+++ b/casadi/interfaces/qpoases/qpoases_interface.cpp
@@ -30,6 +30,7 @@
 
 // Bug in qpOASES?
 #define ALLOW_QPROBLEMB true
+#define ALLOW_ALL_OPTIONS
 
 using namespace std;
 namespace casadi {


### PR DESCRIPTION
This line was missing, now it is possible to actually set options for qpoases