### PR TITLE
Corrected a typo in FindMOSEK.cmake

### DIFF
--- a/cmake/FindMOSEK.cmake
+++ b/cmake/FindMOSEK.cmake
@@ -14,7 +14,7 @@ endif()
 find_library(MOSEK_LIBRARY
   NAMES mosek64
   PATHS ~/mosek/7/tools/platform/linux64x86/bin
-  ${MOSEK}/bin $ENV{MOSEK}/7/tools/platform/linux64x86/bin ~/local/lib /usr/local/lib
+  $ENV{MOSEK}/bin $ENV{MOSEK}/7/tools/platform/linux64x86/bin ~/local/lib /usr/local/lib
 )
 
 if(MOSEK_LIBRARY)


### PR DESCRIPTION
With ${MOSEK} CasADi does not find the library. Changing it to $ENV{MOSEK} resolves the issue.