### PR TITLE
Add define needed to access the SetDllDirectory function on windows

### DIFF
--- a/casadi/core/function/external_function_internal.hpp
+++ b/casadi/core/function/external_function_internal.hpp
@@ -31,6 +31,7 @@
 #ifdef WITH_DL
 #ifdef _WIN32 // also for 64-bit
 #define NOMINMAX
+#define _WIN32_WINNT 0x0502
 #include <windows.h>
 #else // _WIN32
 #include <dlfcn.h>

--- a/casadi/core/function/plugin_interface.hpp
+++ b/casadi/core/function/plugin_interface.hpp
@@ -36,6 +36,7 @@
 #ifdef WITH_DL
 #ifdef _WIN32 // also for 64-bit
 #define NOMINMAX
+#define _WIN32_WINNT 0x0502
 #include <windows.h>
 #else // _WIN32
 #include <dlfcn.h>


### PR DESCRIPTION
On some windows versions, it is necessary to

    #define _WIN32_WINNT 0x0502

(or greater) before including `windows.h` to make the SetDllDirectory function available (see <https://msdn.microsoft.com/en-us/library/windows/desktop/ms686203.aspx>).

Adding this before both places where `windows.h` is included in the CasADi sources. Does this seem like a reasonable way to handle it? I don't get recent CasADi versions to compile on windows without this patch.