### PR TITLE
issue #1461, #1483; readding error beautification

### DIFF
--- a/swig/casadi.i
+++ b/swig/casadi.i
@@ -227,6 +227,26 @@ def _swig_repr(self):
 %feature("compactdefaultargs","0") casadi::Function::generateCode; // buggy
 #endif //SWIGXML
 
+#ifdef SWIGMATLAB
+// This is a first iteration for having
+// beautified error messages in the Matlab iterface
+%feature("matlabprepend") %{
+      try
+%}
+
+%feature("matlabappend") %{
+      catch err
+        if (strcmp(err.identifier,'SWIG:RuntimeError') & strfind(err.message,'No matching function for overload function')==1)
+          msg = [swig_typename_convertor_cpp2matlab(err.message) 'You have: ' strjoin(cellfun(@swig_typename_convertor_matlab2cpp,varargin,'UniformOutput',false),', ')];
+          throwAsCaller(MException(err.identifier,msg));
+        else
+          rethrow(err);
+        end
+      end
+%}
+
+#endif // SWIGMATLAB
+
 // STL
 #ifdef SWIGXML
 namespace std {


### PR DESCRIPTION
@jaeandersson  please consider
```
Error using casadiMEX
No matching function for overload function 'GenSX_sym'.  Possible C/C++ prototypes are:
    casadi::GenericMatrix< casadi::Matrix< casadi::SXElem > >::sym(std::string const &,int,int)
    casadi::GenericMatrix< casadi::Matrix< casadi::SXElem > >::sym(std::string const &,std::pair< int,int > const &)
    casadi::GenericMatrix< casadi::Matrix< casadi::SXElem > >::sym(std::string const &,casadi::Sparsity const &)
    casadi::GenericMatrix< casadi::Matrix< casadi::SXElem > >::sym(std::string const &,casadi::Sparsity const &,int)
    casadi::GenericMatrix< casadi::Matrix< casadi::SXElem > >::sym(std::string const &,int,int,int)
    casadi::GenericMatrix< casadi::Matrix< casadi::SXElem > >::sym(std::string const &,casadi::Sparsity const &,int,int)
    casadi::GenericMatrix< casadi::Matrix< casadi::SXElem > >::sym(std::string const &,int,int,int,int)


Error in casadi.GenSX.sym (line 645)
     [varargout{1:nargout}] = casadiMEX(322, varargin{:});
```

versus

```
No matching function for overload function 'GenSX_sym'.  Possible Matlab usages are:
    SX.sym(char,int,int)
    SX.sym(char,{int,int} )
    SX.sym(char,Sparsity)
    SX.sym(char,Sparsity,int)
    SX.sym(char,int,int,int)
    SX.sym(char,Sparsity,int,int)
    SX.sym(char,int,int,int,int)
You have: double
```

