### PR TITLE
added CMAKE_INSTALL_PREFIX to the python install for local builds

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 
 # NOTE(@jaeandersson): What is this?
 install(DIRECTORY ${PROJECT_BINARY_DIR}/python/casadi
-  DESTINATION "${PYTHON_PREFIX}"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}/${PYTHON_PREFIX}"
   COMPONENT install_python
   USE_SOURCE_PERMISSIONS
   PATTERN .pyc EXCLUDE
@@ -116,26 +116,26 @@ install(DIRECTORY ${PROJECT_BINARY_DIR}/python/casadi
 add_custom_target(install_python
 COMMAND ${CMAKE_COMMAND}
   -D COMPONENT=install_python
-  -D CMAKE_INSTALL_PREFIX="${PYTHON_PREFIX}"
+  -D CMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}/${PYTHON_PREFIX}"
   -P cmake_install.cmake
 )
 add_dependencies(install_python _casadi)
 
 # Install C++ wrapper library
 install(TARGETS _casadi
-  DESTINATION "${PYTHON_PREFIX}/casadi"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}/${PYTHON_PREFIX}/casadi"
   COMPONENT install_python
 )
 
 # Install Python proxy classes
 install(FILES ${PROJECT_BINARY_DIR}/swig/python/casadi.py
-  DESTINATION "${PYTHON_PREFIX}/casadi"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}/${PYTHON_PREFIX}/casadi"
   COMPONENT install_python
 )
 
 # Install Python tools
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tools
-  DESTINATION "${PYTHON_PREFIX}/casadi"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}/${PYTHON_PREFIX}/casadi"
   COMPONENT install_python
   USE_SOURCE_PERMISSIONS
   PATTERN .pyc EXCLUDE
@@ -144,7 +144,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tools
 
 # Install Python package initialization
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
-  DESTINATION "${PYTHON_PREFIX}/casadi"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}/${PYTHON_PREFIX}/casadi"
   COMPONENT install_python
 )
 
@@ -163,17 +163,17 @@ if (WITH_EXTENDING_CASADI)
   add_custom_target(extending_casadi_python DEPENDS _extending_casadi extending_casadi)
 
   install(TARGETS _extending_casadi
-    DESTINATION "${PYTHON_PREFIX}/extending_casadi"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/${PYTHON_PREFIX}/extending_casadi"
     COMPONENT install_python
   )
 
   install(FILES ${PROJECT_BINARY_DIR}/swig/python/extending_casadi.py
-    DESTINATION "${PYTHON_PREFIX}/extending_casadi"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/${PYTHON_PREFIX}/extending_casadi"
     COMPONENT install_python
   )
 
   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../extending_casadi/__init__.py
-    DESTINATION "${PYTHON_PREFIX}/extending_casadi"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/${PYTHON_PREFIX}/extending_casadi"
     COMPONENT install_python
   )
 


### PR DESCRIPTION
I wanted to do prefix installs for testing python. This might help some packaging as well.