### PR TITLE
A cache for SX

### DIFF
--- a/casadi/core/global_options.cpp
+++ b/casadi/core/global_options.cpp
@@ -33,4 +33,6 @@ namespace casadi {
 
   std::string GlobalOptions::casadipath = "";
 
+  bool GlobalOptions::sx_cache = false;
+
 } // namespace casadi

--- a/casadi/core/global_options.hpp
+++ b/casadi/core/global_options.hpp
@@ -61,6 +61,8 @@ namespace casadi {
 
       static bool hierarchical_sparsity;
 
+      static bool sx_cache;
+
 #endif //SWIG
       // Setter and getter for simplification_on_the_fly
       static void setSimplificationOnTheFly(bool flag) { simplification_on_the_fly = flag; }
@@ -72,6 +74,26 @@ namespace casadi {
 
       static void setCasadiPath(const std::string & path) { casadipath = path; }
       static std::string getCasadiPath() { return casadipath; }
+
+      /** \brief Enable caching of unary and binary SX operators.
+           \param enable Set to true to enable caching or false to disable caching
+  
+          When enabled all unary and binary SX operators are cached. Hence, no duplicate
+          expressions will be created. Even the creation of a second commutative binary operator
+          with swapped operants will be avoided by the cache.
+          This cache may significantly reduce the number of nodes in an expression. However,
+          memory usage may increase which may reduce performance.
+          Disabling the cache will not clear the cache just no new entries are added.
+  
+          The cache is disabled per default.
+      */
+      static void setSXCaching(bool enable=true) {
+        sx_cache = enable;
+        // If the cache is enabled permanently (at some later time) the "assert"s in
+        // UnarySX::removeFromCache and BinarySX::removeFromCache should be reenabled.
+      }
+
+      static bool getSXCaching() { return sx_cache; }
 
   };
 

--- a/casadi/core/sx/binary_sx.hpp
+++ b/casadi/core/sx/binary_sx.hpp
@@ -27,6 +27,7 @@
 #define CASADI_BINARY_SX_HPP
 
 #include "sx_node.hpp"
+#include "casadi/core/global_options.hpp"
 #include <stack>
 
 
@@ -72,6 +73,11 @@ class CASADI_EXPORT BinarySX : public SXNode {
         casadi_math<double>::fun(op, dep0_val, dep1_val, ret_val);
         return ret_val;
       } else {
+        if(!GlobalOptions::getSXCaching()) {
+          // Expression containing free variables
+          return SXElem::create(new BinarySX(op, dep0, dep1));
+        }
+
         // The key of the cache
         auto key = std::make_tuple(op, dep0.__hash__(), dep1.__hash__());
         // Find the key in the cache
@@ -175,7 +181,7 @@ class CASADI_EXPORT BinarySX : public SXNode {
     void removeFromCache() {
       // remove from cache
       size_t num_erased = cached_binarysx_.erase(std::make_tuple(op_, dep0_.__hash__(), dep1_.__hash__()));
-      assert(num_erased==1);
+      // assert(num_erased==1); only possible if the cache is enabled permanently
       (void)num_erased;
     }
 

--- a/casadi/core/sx/binary_sx.hpp
+++ b/casadi/core/sx/binary_sx.hpp
@@ -69,7 +69,7 @@ class CASADI_EXPORT BinarySX : public SXNode {
       // Start destruction method if any of the dependencies has dependencies
       for (int c1=0; c1<2; ++c1) {
         // Get the node of the dependency and remove it from the smart pointer
-        SXNode* n1 = dep(c1).assignNoDelete(casadi_limits<SXElem>::nan);
+        SXNode* n1 = const_cast<SXElem&>(dep(c1)).assignNoDelete(casadi_limits<SXElem>::nan);
 
         // Check if this was the last reference
         if (n1->count==0) {
@@ -99,7 +99,7 @@ class CASADI_EXPORT BinarySX : public SXNode {
 
                 // Get the node of the dependency of the top element
                 // and remove it from the smart pointer
-                SXNode *n2 = t->dep(c2).assignNoDelete(casadi_limits<SXElem>::nan);
+                SXNode *n2 = const_cast<SXElem&>(t->dep(c2)).assignNoDelete(casadi_limits<SXElem>::nan);
 
                 // Check if this is the only reference to the element
                 if (n2->count == 0) {
@@ -152,7 +152,6 @@ class CASADI_EXPORT BinarySX : public SXNode {
 
     /** \brief  get the reference of a dependency */
     virtual const SXElem& dep(int i) const { return i==0 ? dep0_ : dep1_;}
-    virtual SXElem& dep(int i) { return i==0 ? dep0_ : dep1_;}
 
     /** \brief  Get the operation */
     virtual int op() const { return op_;}
@@ -179,11 +178,12 @@ class CASADI_EXPORT BinarySX : public SXNode {
       return ss.str();
     }
 
+  protected:
     /** \brief  The binary operation as an 1 byte integer (allows 256 values) */
-    unsigned char op_;
+    const unsigned char op_;
 
     /** \brief  The dependencies of the node */
-    SXElem dep0_, dep1_;
+    const SXElem dep0_, dep1_;
 };
 
 } // namespace casadi

--- a/casadi/core/sx/binary_sx.hpp
+++ b/casadi/core/sx/binary_sx.hpp
@@ -76,6 +76,10 @@ class CASADI_EXPORT BinarySX : public SXNode {
         auto key = std::make_tuple(op, dep0.__hash__(), dep1.__hash__());
         // Find the key in the cache
         auto it = cached_binarysx_.find(key);
+        // If not found and op is commutative try with swapped deps.
+        // This way the same cache for e.g. x+y and y+x is used.
+        if (it==cached_binarysx_.end() && operation_checker<CommChecker>(op))
+          it = cached_binarysx_.find(std::make_tuple(op, dep1.__hash__(), dep0.__hash__()));
         if (it==cached_binarysx_.end()) { // not found -> create new object and return it
           // Allocate a new object
           BinarySX* n = new BinarySX(op, dep0, dep1);

--- a/casadi/core/sx/binary_sx.hpp
+++ b/casadi/core/sx/binary_sx.hpp
@@ -31,7 +31,23 @@
 
 
 /// \cond INTERNAL
+
+#include <unordered_map>
+
 namespace casadi {
+
+// hash the key type of the BinarySX cache
+struct BinarySXCacheKeyHash
+{
+  size_t operator()(const std::tuple<int, size_t, size_t>& v) const
+  {                                              
+    std::size_t ret=0;
+    hash_combine(ret, std::get<0>(v));
+    hash_combine(ret, std::get<1>(v));
+    hash_combine(ret, std::get<2>(v));
+    return ret;
+  }                                              
+};
 
 /** \brief Represents a basic binary operation on two SXElem nodes
   \author Joel Andersson
@@ -56,8 +72,22 @@ class CASADI_EXPORT BinarySX : public SXNode {
         casadi_math<double>::fun(op, dep0_val, dep1_val, ret_val);
         return ret_val;
       } else {
-        // Expression containing free variables
-        return SXElem::create(new BinarySX(op, dep0, dep1));
+        // The key of the cache
+        auto key = std::make_tuple(op, dep0.__hash__(), dep1.__hash__());
+        // Find the key in the cache
+        auto it = cached_binarysx_.find(key);
+        if (it==cached_binarysx_.end()) { // not found -> create new object and return it
+          // Allocate a new object
+          BinarySX* n = new BinarySX(op, dep0, dep1);
+
+          // Add to hash_table
+          cached_binarysx_.emplace_hint(it, key, n);
+
+          // Return it to caller
+          return SXElem::create(n);
+        } else { // found -> return cached object
+          return SXElem::create(it->second);
+        }
       }
     }
 
@@ -66,13 +96,21 @@ class CASADI_EXPORT BinarySX : public SXNode {
     can cause stack overflow due to recursive calling.
     */
     virtual ~BinarySX() {
+      assert(count == 0 || count == SXNode::countToBeDeleted);
+
+      // If count == 0 then this destructor was called directly (not via the none recursive ~BinarySX hack).
+      // In this case remove this node from the cache. If count is SXNode::countToBeDeleted then this node
+      // was already removed from the cache by the call to assignNoDelete in ~BinarySX.
+      if(count==0)
+        removeFromCache();
+
       // Start destruction method if any of the dependencies has dependencies
       for (int c1=0; c1<2; ++c1) {
         // Get the node of the dependency and remove it from the smart pointer
         SXNode* n1 = const_cast<SXElem&>(dep(c1)).assignNoDelete(casadi_limits<SXElem>::nan);
 
-        // Check if this was the last reference
-        if (n1->count==0) {
+        // Check if this was the last reference but node is not deleted already
+        if (n1->count==SXNode::countToBeDeleted) {
 
           // Check if binary
           if (!n1->hasDep()) { // n1 is not binary
@@ -101,8 +139,8 @@ class CASADI_EXPORT BinarySX : public SXNode {
                 // and remove it from the smart pointer
                 SXNode *n2 = const_cast<SXElem&>(t->dep(c2)).assignNoDelete(casadi_limits<SXElem>::nan);
 
-                // Check if this is the only reference to the element
-                if (n2->count == 0) {
+                // Check if this is the only reference to the element but node is not deleted already
+                if (n2->count == SXNode::countToBeDeleted) {
 
                   // Check if binary
                   if (!n2->hasDep()) {
@@ -128,6 +166,13 @@ class CASADI_EXPORT BinarySX : public SXNode {
           }
         }
       }
+    }
+
+    void removeFromCache() {
+      // remove from cache
+      size_t num_erased = cached_binarysx_.erase(std::make_tuple(op_, dep0_.__hash__(), dep1_.__hash__()));
+      assert(num_erased==1);
+      (void)num_erased;
     }
 
     virtual bool is_smooth() const { return operation_checker<SmoothChecker>(op_);}
@@ -184,6 +229,10 @@ class CASADI_EXPORT BinarySX : public SXNode {
 
     /** \brief  The dependencies of the node */
     const SXElem dep0_, dep1_;
+
+    /** \brief Hash map of all binary SX currently allocated
+     * (storage is allocated for it in sx_element.cpp) */
+    static std::unordered_map<std::tuple<int, size_t, size_t>, BinarySX*, BinarySXCacheKeyHash> cached_binarysx_;
 };
 
 } // namespace casadi

--- a/casadi/core/sx/constant_sx.hpp
+++ b/casadi/core/sx/constant_sx.hpp
@@ -33,7 +33,6 @@
 
 // Cashing of constants requires a map
 #include <unordered_map>
-#define CACHING_MAP std::unordered_map
 
 namespace casadi {
 
@@ -96,7 +95,7 @@ class CASADI_EXPORT RealtypeSX : public ConstantSX {
     /// Static creator function (use instead of constructor)
     inline static RealtypeSX* create(double value) {
       // Try to find the constant
-      CACHING_MAP<double, RealtypeSX*>::iterator it = cached_constants_.find(value);
+      std::unordered_map<double, RealtypeSX*>::iterator it = cached_constants_.find(value);
 
       // If not found, add it,
       if (it==cached_constants_.end()) {
@@ -124,7 +123,7 @@ class CASADI_EXPORT RealtypeSX : public ConstantSX {
   protected:
     /** \brief Hash map of all constants currently allocated
      * (storage is allocated for it in sx_element.cpp) */
-    static CACHING_MAP<double, RealtypeSX*> cached_constants_;
+    static std::unordered_map<double, RealtypeSX*> cached_constants_;
 
     /** \brief  Data members */
     double value;
@@ -152,7 +151,7 @@ class CASADI_EXPORT IntegerSX : public ConstantSX {
     /// Static creator function (use instead of constructor)
     inline static IntegerSX* create(int value) {
       // Try to find the constant
-      CACHING_MAP<int, IntegerSX*>::iterator it = cached_constants_.find(value);
+      std::unordered_map<int, IntegerSX*>::iterator it = cached_constants_.find(value);
 
       // If not found, add it,
       if (it==cached_constants_.end()) {
@@ -182,7 +181,7 @@ class CASADI_EXPORT IntegerSX : public ConstantSX {
 
     /** \brief Hash map of all constants currently allocated
      * (storage is allocated for it in sx_element.cpp) */
-    static CACHING_MAP<int, IntegerSX*> cached_constants_;
+    static std::unordered_map<int, IntegerSX*> cached_constants_;
 
     /** \brief  Data members */
     int value;

--- a/casadi/core/sx/sx_node.cpp
+++ b/casadi/core/sx/sx_node.cpp
@@ -112,10 +112,6 @@ namespace casadi {
     casadi_error("child() not defined for class " << typeid(*this).name());
   }
 
-  SXElem& SXNode::dep(int i) {
-    casadi_error("child() not defined for class " << typeid(*this).name());
-  }
-
   bool SXNode::is_smooth() const {
     return true; // nodes are smooth by default
   }

--- a/casadi/core/sx/sx_node.hpp
+++ b/casadi/core/sx/sx_node.hpp
@@ -89,9 +89,6 @@ namespace casadi {
     /** \brief  get the reference of a child */
     virtual const SXElem& dep(int i) const;
 
-    /** \brief  get the reference of a child */
-    virtual SXElem& dep(int i);
-
     /** \brief  Check if smooth */
     virtual bool is_smooth() const;
 

--- a/casadi/core/sx/sx_node.hpp
+++ b/casadi/core/sx/sx_node.hpp
@@ -123,6 +123,11 @@ namespace casadi {
     // Reference counter -- counts the number of parents of the node
     unsigned int count;
 
+    // A special value for count which means that the count is 0 but the SXNode is not deleted but about to be deleted.
+    // (only used in BinarySX::~BinarySX to avoid a recursive call of this destructor)
+    static const decltype(count) countToBeDeleted = std::numeric_limits<decltype(count)>::max();
+
+    virtual void removeFromCache() {}
   };
 
 } // namespace casadi

--- a/casadi/core/sx/sx_node.hpp
+++ b/casadi/core/sx/sx_node.hpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <sstream>
 #include <math.h>
+#include <climits>
 
 /** \brief  Scalar expression (which also works as a smart pointer class to this class) */
 #include "sx_elem.hpp"
@@ -125,7 +126,7 @@ namespace casadi {
 
     // A special value for count which means that the count is 0 but the SXNode is not deleted but about to be deleted.
     // (only used in BinarySX::~BinarySX to avoid a recursive call of this destructor)
-    static const decltype(count) countToBeDeleted = std::numeric_limits<decltype(count)>::max();
+    static const decltype(count) countToBeDeleted = UINT_MAX;
 
     virtual void removeFromCache() {}
   };

--- a/casadi/core/sx/unary_sx.hpp
+++ b/casadi/core/sx/unary_sx.hpp
@@ -77,7 +77,6 @@ class CASADI_EXPORT UnarySX : public SXNode {
 
     /** \brief  get the reference of a dependency */
     virtual const SXElem& dep(int i) const { return dep_; }
-    virtual SXElem& dep(int i) { return dep_; }
 
     /** \brief  Get the operation */
     virtual int op() const { return op_;}
@@ -98,11 +97,12 @@ class CASADI_EXPORT UnarySX : public SXNode {
       return ss.str();
     }
 
+  protected:
     /** \brief  The binary operation as an 1 byte integer (allows 256 values) */
-    unsigned char op_;
+    const unsigned char op_;
 
     /** \brief  The dependencies of the node */
-    SXElem dep_;
+    const SXElem dep_;
 };
 
 } // namespace casadi

--- a/casadi/core/sx/unary_sx.hpp
+++ b/casadi/core/sx/unary_sx.hpp
@@ -27,6 +27,7 @@
 #define UNARY_SXElem_HPP
 
 #include "sx_node.hpp"
+#include "casadi/core/global_options.hpp"
 #include <stack>
 
 /// \cond INTERNAL
@@ -68,6 +69,11 @@ class CASADI_EXPORT UnarySX : public SXNode {
         casadi_math<double>::fun(op, dep_val, dep_val, ret_val);
         return ret_val;
       } else {
+        if(!GlobalOptions::getSXCaching()) {
+          // Expression containing free variables
+          return SXElem::create(new UnarySX(op, dep));
+        }
+
         // The key of the cache
         auto key = std::make_tuple(op, dep.__hash__());
         // Find the key in the cache
@@ -100,7 +106,7 @@ class CASADI_EXPORT UnarySX : public SXNode {
 
     void removeFromCache() {
       size_t num_erased = cached_unarysx_.erase(std::make_tuple(op_, dep_.__hash__()));
-      assert(num_erased==1);
+      // assert(num_erased==1);  only possible if the cache is enabled permanently
       (void)num_erased;
     }
 


### PR DESCRIPTION
Added a cache for the classes UnarySX and BinarySX analog to the cache for ConstantSX. This reduces the number of nodes by avoiding duplicate nodes. (In my test case the number of nodes are reduced by a factor of 2).

This pull request may be related to issue #1540.

The first commit just added some "const" to avoid unintended changes of members.

The second commit adds the cache for UnarySX and BinarySX. The removal of deleted objects from the cache requires some "strange" adaptions due to the already implemented, and complicated, none recursive destructor of BinarySX.

The third commit just uses the same cache entry for BinarySX objects with a commutative operator and swapped dependents.