### PR TITLE
bugfix: include objective sign after parsing

### DIFF
--- a/casadi/core/nlp_builder.cpp
+++ b/casadi/core/nlp_builder.cpp
@@ -106,6 +106,9 @@ namespace casadi {
 
     // Read segments
     parse();
+
+    // multiple the objective sign
+    nlp_.f = sign_*nlp_.f;
   }
 
   NlImporter::~NlImporter() {
@@ -378,10 +381,10 @@ namespace casadi {
     // Should the objective be maximized
     int sigma;
     s_ >> sigma;
-    MX sign = sigma!=0 ? -1 : 1;
+    sign_ = sigma!=0 ? -1 : 1;
 
     // Parse and save expression
-    nlp_.f += sign*expr();
+    nlp_.f += expr();
   }
 
   void NlImporter::d_segment() {

--- a/casadi/core/nlp_builder.hpp
+++ b/casadi/core/nlp_builder.hpp
@@ -98,6 +98,8 @@ namespace casadi {
     std::vector<MX> v_;
     // Number of objectives and constraints
     int n_var_, n_con_, n_obj_, n_eq_, n_lcon_;
+    // objective sign
+    MX sign_;
     // Parse the file
     void parse();
     // Imported function description

--- a/casadi/core/nlp_builder.hpp
+++ b/casadi/core/nlp_builder.hpp
@@ -63,6 +63,8 @@ namespace casadi {
     /// Dual initial guess
     std::vector<double> lambda_init;
 
+    /// Discrete variables
+    std::vector<bool> discrete;
     ///@}
 
     /// Import an .nl file
@@ -98,6 +100,10 @@ namespace casadi {
     std::vector<MX> v_;
     // Number of objectives and constraints
     int n_var_, n_con_, n_obj_, n_eq_, n_lcon_;
+    // nonlinear vars in constraints, objectives, both // see JuliaOpt/AmplNLWriter.jl/src/nl_write.jl
+    int nlvc_, nlvo_, nlvb_;
+    // Number of discrete variables // see JuliaOpt/AmplNLWriter.jl/src/nl_write.jl
+    int nbv_, niv_, nlvbi_, nlvci_, nlvoi_;
     // objective sign
     MX sign_;
     // Parse the file


### PR DESCRIPTION
Currently the sign is multiplied to zero as the objective expression is being parsed after