### PR TITLE
updated link for modelica example in users_guide

### DIFF
--- a/docs/users_guide/casadi-users_guide.tex
+++ b/docs/users_guide/casadi-users_guide.tex
@@ -2579,7 +2579,7 @@ In the following, we will outline the legacy approach, using
 \lstinline[language=Python]{parse_fmi}.
 
 \subsection*{Legacy import of a \texttt{modelDescription.xml} file}
-To see how to use the Modelica import, look at \htmladdnormallink{thermodynamics\_example.py}{https://github.com/casadi/casadi/blob/tested/examples/python/modelica/fritzson_application_examples/thermodynamics_example.py} and \htmladdnormallink{cstr.cpp}{https://github.com/casadi/casadi/blob/tested/examples/cplusplus/cstr.cpp} in \CasADi's example collection.
+To see how to use the Modelica import, look at \htmladdnormallink{thermodynamics\_example.py}{https://github.com/casadi/casadi/blob/master/docs/examples/python/modelica/fritzson_application_examples/thermodynamics_example.py} in \CasADi's example collection.
 
 Assuming that the Modelica/Optimica model \texttt{ModelicaClass.ModelicaModel} is defined in the files \texttt{file1.mo} and \texttt{file2.mop}, the Python compile command is:
 \begin{lstlisting}[language=Python]


### PR DESCRIPTION
- I don' find `cstr.cpp`
- Change link from branch:tested  to branch:master, because new interface (parseFMI -> DaeBuilder) is not in branch:tested.