### PR TITLE
Add cpack and automatic python prefix discovery.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,4 +807,5 @@ install(FILES
 install(EXPORT casadi-targets DESTINATION "${CMAKE_PREFIX}" COMPONENT dev)
 
 set(CPACK_PACKAGE_CONTACT "casadi-users@googlegroups.com")
+set(CPACK_PACKAGE_VERSION ${PACKAGE_VERSION_FULL})
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,16 @@ else()
   set(DEF_BIN_PREFIX bin)
   set(DEF_CMAKE_PREFIX lib/cmake/casadi)
   set(DEF_PYTHON_PREFIX python)
+  if (WITH_PYTHON)
+    set(PYTHON_VERSION_REQ "")
+    if (WITH_PYTHON3)
+      set(PYTHON_VERSION_REQ "3")
+    endif()
+    find_package(PythonInterp ${PYTHON_VERSION_REQ} REQUIRED)
+    execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from __future__ import print_function; from distutils.sysconfig import get_python_lib; print(get_python_lib())"
+      OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(DEF_PYTHON_PREFIX ${PYTHON_SITE_PACKAGES})
+  endif()
   set(DEF_MATLAB_PREFIX matlab)
   set(DEF_INCLUDE_PREFIX include)
 endif()
@@ -795,3 +805,6 @@ install(FILES
 
 # Install the export set for use with the install-tree
 install(EXPORT casadi-targets DESTINATION "${CMAKE_PREFIX}" COMPONENT dev)
+
+set(CPACK_PACKAGE_CONTACT "casadi-users@googlegroups.com")
+include(CPack)


### PR DESCRIPTION
I'm just getting my development environment setup for working with casadi.

Two things:
1. I use anaconda and I wanted to make it auto discover where to put the casadi python stuff.
2. I like using cmake: cpack -G DEB to build packages and install them on ubuntu, so I added support for that.

CPack usage:

```bash
jgoppert@jmg-bnb1:~/git/casadi/build$ cpack -G DEB
CPack: Create package using DEB
CPack: Install projects
CPack: - Run preinstall target for: casadi
CPack: - Install project: casadi
CPack: Create package
CPack: - package: /home/jgoppert/git/casadi/build/casadi-0.1.1-Linux.deb generated.
jgoppert@jmg-bnb1:~/git/casadi/build$ sudo dpkg -i casadi-0.1.1-Linux.deb 
```