### PR TITLE
Fixed a typo in the user guide

### DIFF
--- a/docs/users_guide/casadi-users_guide.tex
+++ b/docs/users_guide/casadi-users_guide.tex
@@ -3028,7 +3028,7 @@ with $T=10$.
 In \CasADi's examples collection\footnote{You can obtain this collection as an archive named \texttt{examples\_pack.zip} in \CasADi's \htmladdnormallink{download area}{http://files.casadi.org}}, you find codes for solving optimal control problems using a variety of different methods.
 
 In the following, we will discuss three of the most important methods, namely
-\emph{direct single shooting}, \emph{direct collocation} and \emph{direct collocation}.
+\emph{direct single shooting}, \emph{direct multiple shooting} and \emph{direct collocation}.
 
 \section{Direct single-shooting}
 


### PR DESCRIPTION
"direct collocation" was repeated twice instead of mentioning "direct multiple shooting".