### PR TITLE
Make linspace() non-recursive

### DIFF
--- a/casadi/core/generic_matrix.hpp
+++ b/casadi/core/generic_matrix.hpp
@@ -946,7 +946,7 @@ namespace casadi {
     MatType step = (b-a)/static_cast<MatType>(nsteps-1);
 
     for (casadi_int i=1; i<nsteps-1; ++i)
-      ret[i] = ret[i-1] + step;
+      ret[i] = a + i * step;
 
     ret[nsteps-1] = b;
     return vertcat(ret);


### PR DESCRIPTION
For a "linspace(a, b, num)" call with "a" and/or "b" symbolic expressions,
the recursive implementation would lead to a graph of "num" depth. For
large "num" this can lead to e.g. a very slow "is_equal" check due to the
depth requirement.

Another reason to prefer a multiplication over recursive addition is
eliminating the compounding error due to rounding when calling linspace
with numeric arguments.