### PR TITLE
Delete DeserializingStream's copy constructor to avoid UniversalNodeOwner errors

### DIFF
--- a/casadi/core/serializing_stream.hpp
+++ b/casadi/core/serializing_stream.hpp
@@ -67,6 +67,7 @@ namespace casadi {
   public:
     /// Constructor
     DeserializingStream(std::istream &in_s);
+    DeserializingStream(const DeserializingStream&) = delete;
 
     //@{
     /** \brief Reconstruct an object from the input stream


### PR DESCRIPTION
This PR addresses #2383. Visual Studio builds fail related to trying to reference a UniversalNodeOwner's deleted copy constructor. Also deleting DeserializingStream's copy constructor seems to fix the issue.