### PR TITLE
CbcInterface: Fix erroneous passing of hot_start as cmd argument

### DIFF
--- a/casadi/interfaces/cbc/cbc_interface.cpp
+++ b/casadi/interfaces/cbc/cbc_interface.cpp
@@ -315,6 +315,9 @@ namespace casadi {
     // Read Osi options
     for (auto&& op : opts_) {
       {
+        if (op.first=="hot_start") continue;
+      }
+      {
         // Check for double params
         auto it = param_map_double.find(op.first);
         if (it!=param_map_double.end()) {


### PR DESCRIPTION
A separate issue is that hot_start needs to be explicitly set for CBC, but for CPLEX/Gurobi it's enabled by default (and cannot actually be disabled as far as I can tell).