### PR TITLE
CbcInterface: Fix disappearing log messages

### DIFF
--- a/casadi/interfaces/cbc/cbc_interface.cpp
+++ b/casadi/interfaces/cbc/cbc_interface.cpp
@@ -185,16 +185,6 @@ namespace casadi {
     }
   }
 
-  class CasadiHandler : public CoinMessageHandler {
-    public:
-      virtual int print() ;
-  };
-
-  int CasadiHandler::print() {
-    uout() << messageBuffer() << std::endl;
-    return 0;
-  }
-
   void CbcInterface::init(const Dict& opts) {
     // Call the init method of the base class
     Conic::init(opts);
@@ -364,9 +354,6 @@ namespace casadi {
 
     std::vector<const char*> main_options_char;
     for (const auto& s : main1_options) main_options_char.push_back(s.c_str());
-
-    CasadiHandler ch;
-    model.passInMessageHandler(&ch);
 
     m->fstats.at("preprocessing").toc();
     m->fstats.at("solver").tic();


### PR DESCRIPTION
Messages from Cbc were disappearing in the message handler. We can
remove it entirely, which makes sure the message show up again in
stdout/stderr. Note that unlike with the Clp interface, the user can
properly capture stdout and stderr as-is. No special capturing/piping of
messages is therefore necessary.