### PR TITLE
Fixed a bug in nlpsol iteration callback

### DIFF
--- a/casadi/core/nlpsol.cpp
+++ b/casadi/core/nlpsol.cpp
@@ -940,7 +940,7 @@ namespace casadi {
     // Callback outputs
     fill_n(m->res, fcallback_.n_out(), nullptr);
     double ret = 0;
-    m->arg[0] = &ret;
+    m->res[0] = &ret;
 
     // Start timer
     m->fstats.at("callback_fun").tic();


### PR DESCRIPTION
I fixed the bug described here: 
https://groups.google.com/forum/#!searchin/casadi-users/iteration$20callback%7Csort:date/casadi-users/Sxg9Cwi6Q7g/3jeN1eMgCQAJ
It turned out line 943 of nlpsol was wrong.
It was: 
m->arg[0] = &ret;
Where it should have been
m->res[0] = &ret;

This should be the only change in this PR. 