### PR TITLE
added function name in error message when function inputs are not purely symbolic

### DIFF
--- a/casadi/core/x_function.hpp
+++ b/casadi/core/x_function.hpp
@@ -280,7 +280,7 @@ namespace casadi {
     // Make sure that inputs are symbolic
     for (casadi_int i=0; i<n_in_; ++i) {
       if (in_.at(i).nnz()>0 && !in_.at(i).is_valid_input()) {
-        casadi_error("Xfunction input arguments must be purely symbolic. \n"
+        casadi_error("For " + this->name_ + ": Xfunction input arguments must be purely symbolic. \n"
                      "Argument " + str(i) + "(" + name_in_[i] + ") is not symbolic.");
       }
     }


### PR DESCRIPTION
This facilitates debugging when you have a million functions and you're not sure which one is the problem.