### PR TITLE
Compute determinant for MX using CSparse

### DIFF
--- a/casadi/core/determinant.cpp
+++ b/casadi/core/determinant.cpp
@@ -5,6 +5,7 @@
  *    Copyright (C) 2010-2014 Joel Andersson, Joris Gillis, Moritz Diehl,
  *                            K.U. Leuven. All rights reserved.
  *    Copyright (C) 2011-2014 Greg Horn
+ *    Copyright (C) 2018 Robert Bosch GmbH
  *
  *    CasADi is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -29,7 +30,7 @@ using namespace std;
 
 namespace casadi {
 
-  Determinant::Determinant(const MX& x) {
+  Determinant::Determinant(const MX& x) : linsol_("lu","csparse",x.sparsity()) {
     casadi_assert(x.is_square(), "Dimension mismatch. Matrix must be square, "
       "but got " + x.dim() + " instead.");
     set_dep(x);
@@ -38,6 +39,28 @@ namespace casadi {
 
   std::string Determinant::disp(const std::vector<std::string>& arg) const {
     return "det(" + arg.at(0) + ")";
+  }
+
+  int Determinant::eval(const double** arg, double** res, casadi_int* iw, double* w) const {
+    /**
+     * Consideration:
+     *  - Note that a typical implementation of the partial derivative of a determinant
+     *    involves computing both the determinant and the inverse of a matrix. There is
+     *    efficiency to be gained through reusing the matrix factorization for both
+     *    operations.
+     * 
+     */
+
+    scoped_checkout<Linsol> mem(linsol_);
+
+    // Peform LU decomposition
+    if (linsol_.sfact(arg[0], mem)) return 1;
+    if (linsol_.nfact(arg[0], mem)) return 1;
+
+    // Compute determinant
+    res[0][0] = linsol_.det(arg[0], mem);
+
+    return 0;
   }
 
   void Determinant::eval_mx(const std::vector<MX>& arg, std::vector<MX>& res) const {

--- a/casadi/core/determinant.cpp
+++ b/casadi/core/determinant.cpp
@@ -30,7 +30,7 @@ using namespace std;
 
 namespace casadi {
 
-  Determinant::Determinant(const MX& x) : linsol_("lu","csparse",x.sparsity()) {
+  Determinant::Determinant(const MX& x) : linsol_("lu", "csparse", x.sparsity()) {
     casadi_assert(x.is_square(), "Dimension mismatch. Matrix must be square, "
       "but got " + x.dim() + " instead.");
     set_dep(x);

--- a/casadi/core/determinant.hpp
+++ b/casadi/core/determinant.hpp
@@ -27,6 +27,7 @@
 #define CASADI_DETERMINANT_HPP
 
 #include "mx_node.hpp"
+#include "linsol_internal.hpp"
 #include <map>
 #include <stack>
 
@@ -45,6 +46,9 @@ namespace casadi {
 
     /// Destructor
     ~Determinant() override {}
+
+    /** \brief Evaluate the function numerically */
+    int eval(const double** arg, double** res, casadi_int* iw, double* w) const override;
 
     /** \brief  Evaluate symbolically (MX) */
     void eval_mx(const std::vector<MX>& arg, std::vector<MX>& res) const override;
@@ -65,6 +69,9 @@ namespace casadi {
 
     /** \brief Deserialize without type information */
     static MXNode* deserialize(DeserializingStream& s) { return new Determinant(s); }
+
+    // CSparse interface
+    Linsol linsol_;
 
   protected:
     /** \brief Deserializing constructor */

--- a/casadi/core/linsol.cpp
+++ b/casadi/core/linsol.cpp
@@ -146,6 +146,12 @@ namespace casadi {
     return 0;
   }
 
+  double Linsol::det(const double* A, int mem) const {
+    auto m = static_cast<LinsolMemory*>((*this)->memory(mem));
+    casadi_assert(m->is_nfact, "Linear system has not been factorized");
+    return (*this)->det(m, A);
+  }
+
   casadi_int Linsol::neig(const DM& A) const {
     if (A.sparsity()!=sparsity()) return neig(project(A, sparsity()));
     casadi_int n = neig(A.ptr());

--- a/casadi/core/linsol.hpp
+++ b/casadi/core/linsol.hpp
@@ -124,7 +124,7 @@ namespace casadi {
     int sfact(const double* A, int mem=0) const;
     int nfact(const double* A, int mem=0) const;
     int solve(const double* A, double* x, casadi_int nrhs=1, bool tr=false, int mem=0) const;
-    double det(const double *, int mem = 0) const;
+    double det(const double* A, int mem = 0) const;
     casadi_int neig(const double* A, int mem=0) const;
     casadi_int rank(const double* A, int mem=0) const;
     ///@}

--- a/casadi/core/linsol.hpp
+++ b/casadi/core/linsol.hpp
@@ -124,6 +124,7 @@ namespace casadi {
     int sfact(const double* A, int mem=0) const;
     int nfact(const double* A, int mem=0) const;
     int solve(const double* A, double* x, casadi_int nrhs=1, bool tr=false, int mem=0) const;
+    double det(const double *, int mem = 0) const;
     casadi_int neig(const double* A, int mem=0) const;
     casadi_int rank(const double* A, int mem=0) const;
     ///@}

--- a/casadi/core/linsol_internal.cpp
+++ b/casadi/core/linsol_internal.cpp
@@ -100,6 +100,10 @@ namespace casadi {
     casadi_error("'nfact' not defined for " + class_name());
   }
 
+  double LinsolInternal::det(void* mem, const double* A) const {
+    casadi_error("'det' not defined for " + class_name());
+  }
+
   casadi_int LinsolInternal::neig(void* mem, const double* A) const {
     casadi_error("'neig' not defined for " + class_name());
   }

--- a/casadi/core/linsol_internal.hpp
+++ b/casadi/core/linsol_internal.hpp
@@ -97,6 +97,9 @@ namespace casadi {
     // Solve numerically
     virtual int solve(void* mem, const double* A, double* x, casadi_int nrhs, bool tr) const;
 
+    /// Determinant
+    virtual double det(void* mem, const double* A) const;
+
     /// Number of negative eigenvalues
     virtual casadi_int neig(void* mem, const double* A) const;
 

--- a/casadi/interfaces/csparse/csparse_interface.hpp
+++ b/casadi/interfaces/csparse/csparse_interface.hpp
@@ -93,6 +93,9 @@ namespace casadi {
     // Factorize the linear system
     int nfact(void* mem, const double* A) const override;
 
+    // Determinant
+    double det(void* mem, const double* A) const override;
+
     // Solve the linear system
     int solve(void* mem, const double* A, double* x, casadi_int nrhs, bool tr) const override;
 


### PR DESCRIPTION
This PRQ adds a determinant computation for large sparse matrices using the LU decomposition of CSparse. This is useful for e.g., optimal experiment design where the D-optimality criterion involves computing the determinant.

Any feedback is welcome, let me know if you want to move the copyright notice.