### PR TITLE
add build compatibility with ARM64 (aarch64) processors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,7 @@ endif()
 #######################################################################
 # the following commands are needed to fix a problem with the libraries
 # for linux 64 bits
-if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
   message(STATUS "x86_64 architecture detected - setting flag -fPIC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")


### PR DESCRIPTION
Good morning,
today I've tried to build CasADi from source on a Jetson AGX Xavier.
At first, I've encountered many errors that states to recompile with '-fPIC' option.
This little fix seems to make everything compile successfully.

Regards.