### PR TITLE
Add the support to osqp 0.6.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/snopt/snopt-interface.git
 [submodule "external_packages/osqp/osqp"]
 	path = external_packages/osqp/osqp
-	url = https://github.com/jgillis/osqp.git
+	url = https://github.com/oxfordcontrol/osqp.git
 [submodule "external_packages/superscs"]
 	path = external_packages/superscs
 	url = https://github.com/jgillis/scs.git

--- a/casadi/interfaces/osqp/CMakeLists.txt
+++ b/casadi/interfaces/osqp/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8.6)
 
+option(USE_SYSTEM_WISE_OSQP "Use a systemwise installation of osqp" OFF)
+
 include_directories(../)
 
 casadi_plugin(Conic osqp
@@ -7,7 +9,13 @@ casadi_plugin(Conic osqp
   osqp_interface.cpp
   osqp_interface_meta.cpp)
 
-casadi_plugin_link_libraries(Conic osqp osqp)
+# Add the possibility to use a systemwise installation of casadi
+if(USE_SYSTEM_WISE_OSQP)
+  find_package(osqp REQUIRED)
+  casadi_plugin_link_libraries(Conic osqp osqp::osqp)
+else()
+  casadi_plugin_link_libraries(Conic osqp osqp)
+endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 set_target_properties(casadi_conic_osqp PROPERTIES COMPILE_FLAGS "-Wno-unused-variable -Wno-unknown-warning-option")

--- a/external_packages/osqp/CMakeLists.txt
+++ b/external_packages/osqp/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 2.8.6)
 
-#set(EMBEDDED 1)
-set(ENABLE_MKL_PARDISO OFF CACHE BOOL "Enable MKL Pardiso solver")
-set(PROFILING OFF CACHE BOOL "Enable solver profiling (timing)")
-set(CMAKE_INSTALL_INCLUDEDIR ${INCLUDE_PREFIX})
-set(CMAKE_INSTALL_LIBDIR ${LIB_PREFIX})
-set(CMAKE_INSTALL_BINDIR ${BIN_PREFIX})
-add_subdirectory(osqp)
-
+if(NOT USE_SYSTEM_WISE_OSQP)
+  set(ENABLE_MKL_PARDISO OFF CACHE BOOL "Enable MKL Pardiso solver")
+  set(CMAKE_INSTALL_INCLUDEDIR ${INCLUDE_PREFIX})
+  set(CMAKE_INSTALL_LIBDIR ${LIB_PREFIX})
+  set(CMAKE_INSTALL_BINDIR ${BIN_PREFIX})
+  add_subdirectory(osqp)
+endif()


### PR DESCRIPTION
This PR fixes #2670. In details:
1.  the `osqp_interface.cpp` has been modified in order to be compliant with `osqp 0.6.0`
2. the `osqp` submodules is now updated to `osqp 0.6.0`
3. `USE_SYSTEM_WISE_OSQP` option has been added. The default value of the option is `OFF`. When `USE_SYSTEM_WISE_OSQP` is equal to `ON`, a system installation of `osqp` is searched, if `USE_SYSTEM_WISE_OSQP` is `OFF` the repository stored in ` external_packages/osqp/osqp` is built and installed.

cc @traversaro @S-dafarra 