### PR TITLE
Opti.subject_to() clears constraints data #2512

### DIFF
--- a/casadi/core/optistack_internal.cpp
+++ b/casadi/core/optistack_internal.cpp
@@ -921,6 +921,12 @@ void OptiNode::subject_to(const MX& g) {
 void OptiNode::subject_to() {
   mark_problem_dirty();
   g_.clear();
+
+  // Remove symbols associated_with existing constraints
+  for (casadi_int i=0; i<symbols_.size(); i++) {
+    if (get_meta(symbols_[i]).type == OPTI_DUAL_G) symbols_.erase(symbols_.begin()+i);
+  }
+
   store_initial_[OPTI_DUAL_G].clear();
   store_latest_[OPTI_DUAL_G].clear();
   count_dual_ = 0;

--- a/casadi/core/optistack_internal.cpp
+++ b/casadi/core/optistack_internal.cpp
@@ -1080,13 +1080,15 @@ DM OptiNode::value(const MX& expr, const std::vector<MX>& values) const {
   }
 
   bool undecided_vars = false;
+
   std::vector<DM> x_num;
   for (const auto& e : x) {
     casadi_int i = meta(e).i;
     x_num.push_back(store_latest_.at(OPTI_VAR).at(i));
     undecided_vars |= override_num(temp[OPTI_VAR], x_num, i);
+    // if numeric value x_var is overridden set undecided_vars true
   }
-
+  // lam
   std::vector<DM> lam_num;
   for (const auto& e : lam) {
     casadi_int i = meta(e).i;

--- a/casadi/core/optistack_internal.hpp
+++ b/casadi/core/optistack_internal.hpp
@@ -167,6 +167,7 @@ public:
   MX dual(const MX& m) const;
 
   void assert_active_symbol(const MX& m) const;
+  void assert_active_symbol_(const MX& m, const std::string& error_msg) const;
 
   std::vector<MX> active_symvar(VariableType type) const;
   std::vector<DM> active_values(VariableType type) const;
@@ -351,7 +352,7 @@ private:
   std::map< VariableType, std::vector<DM> > store_initial_, store_latest_;
 
   /// Is symbol present in problem?
-  std::vector<bool> symbol_active_;
+  std::map<casadi_int, bool> symbol_active_;
 
   /// Solver
   Function solver_;

--- a/casadi/core/optistack_internal.hpp
+++ b/casadi/core/optistack_internal.hpp
@@ -101,6 +101,7 @@ public:
 
   /// @{
   /// Obtain value of expression at the current value
+  /// Optionally set different values for some symbol in expression
   DM value(const MX& x, const std::vector<MX>& values=std::vector<MX>()) const;
   DM value(const DM& x, const std::vector<MX>& values=std::vector<MX>()) const { return x; }
   DM value(const SX& x, const std::vector<MX>& values=std::vector<MX>()) const {

--- a/test/python/optistack.py
+++ b/test/python/optistack.py
@@ -975,5 +975,21 @@ class OptiStacktests(inherit_from):
       self.checkarray(res,DM([5-8/sqrt(5),7-4/sqrt(5)]),conic,digits=7)
       self.checkarray(sol.value(opti.f),10-16/sqrt(5)+7-4/sqrt(5),conic,digits=7)
 
+    def test_subject_to_symbols_clear(self):
+
+      opti = Opti()
+      x = opti.variable()
+      opti.subject_to(x>=1)
+      opti.minimize(x**2)
+
+      opti.subject_to()
+      opti.subject_to(x<=5)
+
+      opti.solver(nlpsolver,nlpsolver_options)
+      sol = opti.solve()
+
+      self.assertEqual(len(opti.debug.symvar()),2)
+      self.assertEqual(len(opti.initial()),2)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/optistack.py
+++ b/test/python/optistack.py
@@ -47,7 +47,6 @@ if has_nlpsol("ipopt"):
 
 class OptiStacktests(inherit_from):
 
-
     @requires_conic("qrqp")
     def test_conic(self):
       opti = Opti('conic')
@@ -62,7 +61,6 @@ class OptiStacktests(inherit_from):
 
       with self.assertInException("conic"):
         Opti('foo')
-
 
     def test_lookup(self):
       opti = Opti()
@@ -79,8 +77,6 @@ class OptiStacktests(inherit_from):
       self.assertEqual(str2,str3)
       
       self.assertFalse(str1==str2)
-     
-      
       
     def test_n(self):
       opti = Opti()
@@ -212,8 +208,6 @@ class OptiStacktests(inherit_from):
       opti.solver(nlpsolver,nlpsolver_options)
 
       sol = opti.solve()
-      
- 
 
     def test_sparse(self):
       opti = Opti()
@@ -251,7 +245,6 @@ class OptiStacktests(inherit_from):
       hess_lag = sol.value(hessian(opti.f+dot(opti.lam_g,opti.g),opti.x)[0])
       self.checkarray(sol.value(hess_lag),sol.value(tril2symm(sol.opti.debug.casadi_solver.get_function('nlp_hess_l')(opti.x,opti.p,1,opti.lam_g).T)))
 
-
     def test_warmstart(self):
       opti = Opti()
 
@@ -287,7 +280,6 @@ class OptiStacktests(inherit_from):
       opti.set_value(sol1.value_parameters())
       sol = opti.solve()
       self.checkarray(sol.value(x),sol1.value(x), digits=6)
-      
       
     def test_set_value_expr(self):
 
@@ -376,7 +368,6 @@ class OptiStacktests(inherit_from):
          
           with self.assertInException("!parametric[0]"):
             opti.subject_to(x<=y)
-
           
     def test_callback(self):
         
@@ -591,8 +582,6 @@ class OptiStacktests(inherit_from):
         sol.value(dual)
       with self.assertInException("optistack.py"):
         sol.value(dual)
-      
-        
         
     def test_simple(self):
       
@@ -879,7 +868,6 @@ class OptiStacktests(inherit_from):
           opti.subject_to(x[0]==vertcat(1,2,3))
         with self.assertInException("Constraint shape mismatch."):
           opti.subject_to(vertcat(1,2,3)==x[0])
-
 
     def test_value(self):
         opti = Opti()


### PR DESCRIPTION
- Erase old dual constraints var symbols from `symbols_` vector
- Make `symbol_active_` a map in oder to use increasing var id (MetaVar.count)
 Not sure how much this is less efficient and if it may be a problem

Constraints and dual constraints var metadata should be deleted as well?
A possible motivation to keep them is that constraints referenced by Python variables
can still be used in future problem formulation. 