### PR TITLE
HiGHS interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -708,6 +708,13 @@ if(WITH_SNOPT)
 endif()
 add_feature_info(snopt-interface WITH_SNOPT "Interface to the NLP solver SNOPT.")
 
+# HIGHS: A MILP / QP solver
+option(WITH_HIGHS "Compile the HIGHS interface" OFF)
+if(WITH_HIGHS)
+  find_package(HIGHS REQUIRED)
+endif()
+add_feature_info(highs-interface WITH_HIGHS "Interface to the MILP / QP solver HIGHS.")
+
 # HSL: Sparse direct linear solvers
 option(WITH_HSL "Enable HSL interface" OFF)
 if(WITH_HSL)

--- a/casadi/interfaces/CMakeLists.txt
+++ b/casadi/interfaces/CMakeLists.txt
@@ -42,6 +42,10 @@ if(WITH_CLANG)
   add_subdirectory(clang)
 endif()
 
+if(WITH_HIGHS)
+  add_subdirectory(highs)
+endif()
+
 if(WITH_HSL)
   add_subdirectory(hsl)
 endif()

--- a/casadi/interfaces/highs/CMakeLists.txt
+++ b/casadi/interfaces/highs/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8.6)
+
+include_directories(${HIGHS_INCLUDE_DIRS})
+link_directories(${HIGHS_LIBRARY_DIRS})
+
+casadi_plugin(Conic highs
+  highs_interface.hpp
+  highs_interface.cpp
+  highs_interface_meta.cpp)
+casadi_plugin_link_libraries(Conic highs ${HIGHS_LIBRARIES})
+
+#if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+#set_target_properties(casadi_conic_cbc PROPERTIES COMPILE_FLAGS "-Wno-misleading-indentation -Wno-unknown-warning-option")
+#endif()

--- a/casadi/interfaces/highs/highs_interface.cpp
+++ b/casadi/interfaces/highs/highs_interface.cpp
@@ -1,0 +1,298 @@
+/*
+ *    This file is part of CasADi.
+ *
+ *    CasADi -- A symbolic framework for dynamic optimization.
+ *    Copyright (C) 2010-2014 Joel Andersson, Joris Gillis, Moritz Diehl,
+ *                            K.U. Leuven. All rights reserved.
+ *    Copyright (C) 2011-2014 Greg Horn
+ *
+ *    CasADi is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation; either
+ *    version 3 of the License, or (at your option) any later version.
+ *
+ *    CasADi is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public
+ *    License along with CasADi; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "highs_interface.hpp"
+
+#include "casadi/core/nlp_tools.hpp"
+
+namespace casadi {
+
+  using namespace std;
+
+  extern "C"
+  int CASADI_CONIC_HIGHS_EXPORT
+  casadi_register_conic_highs(Conic::Plugin* plugin) {
+    plugin->creator = HighsInterface::creator;
+    plugin->name = "highs";
+    plugin->doc = HighsInterface::meta_doc.c_str();
+    plugin->version = CASADI_VERSION;
+    plugin->options = &HighsInterface::options_;
+    plugin->deserialize = &HighsInterface::deserialize;
+    return 0;
+  }
+
+  extern "C"
+  void CASADI_CONIC_HIGHS_EXPORT casadi_load_conic_highs() {
+    Conic::registerPlugin(casadi_register_conic_highs);
+  }
+
+
+  HighsInterface::HighsInterface(const std::string& name,
+                             const std::map<std::string, Sparsity>& st)
+    : Conic(name, st) {
+  }
+
+  const Options HighsInterface::options_
+  = {{&Conic::options_},
+     {{"highs",
+       {OT_DICT,
+        "Options to be passed to HiGHS."
+        }},
+     }
+   };
+
+  // Options with description https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.html
+  std::list<std::string> HighsInterface::param_bool = {
+    "output_flag",
+    "log_to_console",
+    "write_solution_to_file",
+    "mip_detect_symmetry"
+  };
+
+  void HighsInterface::init(const Dict& opts) {
+    // Call the init method of the base class
+    Conic::init(opts);
+
+    // Read user options
+    for (auto&& op : opts) {
+      if (op.first=="highs") {
+        opts_ = op.second;
+      }
+    }
+
+    // Allocate work vectors
+    alloc_w(nx_, true); // g
+    alloc_w(nx_, true); // lbx
+    alloc_w(nx_, true); // ubx
+    alloc_w(na_, true); // lba
+    alloc_w(na_, true); // uba
+    alloc_w(nnz_in(CONIC_H), true); // H
+    alloc_w(nnz_in(CONIC_A), true); // A
+  }
+
+  int HighsInterface::init_mem(void* mem) const {
+    if (Conic::init_mem(mem)) return 1;
+    if (!mem) return 1;
+    auto m = static_cast<HighsMemory*>(mem);
+
+    m->add_stat("preprocessing");
+    m->add_stat("solver");
+    m->add_stat("postprocessing");
+
+    m->colinda.resize(A_.size2()+1);
+    m->rowa.resize(A_.nnz());
+    m->colindh.resize(H_.size2()+1);
+    m->rowh.resize(H_.nnz());
+    m->integrality.resize(nx_);
+
+    return 0;
+  }
+
+  int HighsInterface::
+  solve(const double** arg, double** res, casadi_int* iw, double* w, void* mem) const {
+    auto m = static_cast<HighsMemory*>(mem);
+
+    // Problem has not been solved at this point
+    m->return_status = static_cast<int>(HighsStatus::kError);
+
+    m->fstats.at("preprocessing").tic();
+
+    // Get inputs
+    double* g=w; w += nx_;
+    casadi_copy(arg[CONIC_G], nx_, g);
+    double* lbx=w; w += nx_;
+    casadi_copy(arg[CONIC_LBX], nx_, lbx);
+    double* ubx=w; w += nx_;
+    casadi_copy(arg[CONIC_UBX], nx_, ubx);
+    double* lba=w; w += na_;
+    casadi_copy(arg[CONIC_LBA], na_, lba);
+    double* uba=w; w += na_;
+    casadi_copy(arg[CONIC_UBA], na_, uba);
+    double* H=w; w += nnz_in(CONIC_H);
+    casadi_copy(arg[CONIC_H], nnz_in(CONIC_H), H);
+    double* A=w; w += nnz_in(CONIC_A);
+    casadi_copy(arg[CONIC_A], nnz_in(CONIC_A), A);
+
+    copy_vector(A_.colind(), m->colinda);
+    copy_vector(A_.row(), m->rowa);
+    copy_vector(H_.colind(), m->colindh);
+    copy_vector(H_.row(), m->rowh);
+
+
+    // Create HiGHS instance and pass problem
+    Highs highs;
+    HighsStatus status;
+    const int matrix_format = 1;
+    const int sense = 1;
+    const double offset = 0.0;
+
+    // set HiGHS options, option verification is done by HiGHS
+    for (auto&& op : opts_) {
+      auto it = std::find(param_bool.begin(), param_bool.end(), op.first);
+      if(it != param_bool.end() || op.second.getType() == OT_BOOL) {
+        casadi_assert(highs.setOptionValue(op.first, op.second.to_bool()) == HighsStatus::kOk,
+          "Error setting option '" + op.first + "'.");
+      } 
+      else if(op.second.getType() == OT_INT){
+        casadi_assert(highs.setOptionValue(op.first, static_cast<int>(op.second.to_int())) == HighsStatus::kOk,
+          "Error setting option '" + op.first + "'.");
+      }
+      else if(op.second.getType() == OT_DOUBLE) {
+        casadi_assert(highs.setOptionValue(op.first, op.second.to_double()) == HighsStatus::kOk,
+          "Error setting option '" + op.first + "'.");
+      }
+      else if(op.second.getType() == OT_STRING) {
+        casadi_assert(highs.setOptionValue(op.first, op.second.to_string()) == HighsStatus::kOk,
+          "Error setting option '" + op.first + "'.");
+      }
+      else {
+        casadi_assert(false, "Option type for '" + op.first + "'not supported!");
+      }
+    }
+
+    // if variables are declared as discrete, set integrality pointer and flag discrete variables
+    int* integrality_ptr = nullptr;
+    if (!discrete_.empty()) {
+      integrality_ptr = get_ptr(m->integrality);
+      for (casadi_int i=0; i<nx_; ++i) {
+        m->integrality[i] = discrete_.at(i) ? 1 : 0;
+      }
+    }
+    status = highs.passModel(nx_, na_, nnz_in(CONIC_A), nnz_in(CONIC_H),
+      matrix_format, matrix_format, sense, offset,
+      g, lbx, ubx, lba, uba,
+      get_ptr(m->colinda), get_ptr(m->rowa), A,
+      get_ptr(m->colindh), get_ptr(m->rowh), H,      
+      integrality_ptr);
+    
+    // check that passing model is successful
+    casadi_assert(status == HighsStatus::kOk, "invalid data to build HiGHS model");
+
+    m->fstats.at("preprocessing").toc();
+    m->fstats.at("solver").tic();
+
+    // solve incumbent model
+    status = highs.run();
+    casadi_assert(status == HighsStatus::kOk, "running HiGHS failed");
+    
+    m->fstats.at("solver").toc();
+    m->fstats.at("postprocessing").tic();
+
+    // get primal and dual solution
+    HighsSolution solution = highs.getSolution();
+    casadi_copy(solution.col_value.data(), nx_, res[CONIC_X]);
+    
+    if (res[CONIC_LAM_X]) {
+      casadi_copy(solution.col_dual.data(), nx_, res[CONIC_LAM_X]);
+      casadi_scal(nx_, -1., res[CONIC_LAM_X]);
+    }
+    if (res[CONIC_LAM_A]) {
+      casadi_copy(solution.row_dual.data(), na_, res[CONIC_LAM_A]);
+      casadi_scal(na_, -1., res[CONIC_LAM_A]);
+    }
+    // get information
+    const HighsInfo& info = highs.getInfo();
+
+    if (res[CONIC_COST]) {
+      *res[CONIC_COST] = info.objective_function_value;
+    }
+
+    m->fstats.at("postprocessing").toc();
+
+    HighsModelStatus model_status = highs.getModelStatus();
+    m->return_status = static_cast<int>(model_status);
+    m->success = model_status==HighsModelStatus::kOptimal;
+
+    if (model_status==HighsModelStatus::kTimeLimit
+          || model_status==HighsModelStatus::kIterationLimit)
+      m->unified_return_status = SOLVER_RET_LIMITED;
+
+    m->simplex_iteration_count = info.simplex_iteration_count;
+    m->simplex_iteration_count = info.simplex_iteration_count;
+    m->ipm_iteration_count = info.ipm_iteration_count;
+    m->qp_iteration_count = info.qp_iteration_count;
+    m->crossover_iteration_count = info.crossover_iteration_count;
+    m->primal_solution_status  = info.primal_solution_status;
+    m->dual_solution_status = info.dual_solution_status;
+    m->basis_validity = info.basis_validity;
+    m->mip_dual_bound = info.mip_dual_bound;
+    m->mip_gap = info.mip_gap;
+    m->num_primal_infeasibilities = info.num_primal_infeasibilities;
+    m->max_primal_infeasibility = info.max_primal_infeasibility;
+    m->sum_primal_infeasibilities = info.sum_primal_infeasibilities;
+    m->num_dual_infeasibilities = info.num_dual_infeasibilities;
+    m->max_dual_infeasibility = info.max_dual_infeasibility;
+    m->sum_dual_infeasibilities = info.sum_dual_infeasibilities;
+
+    return 0;
+  }
+
+  HighsInterface::~HighsInterface() {
+    clear_mem();
+  }
+
+  HighsMemory::HighsMemory() {
+  }
+
+  HighsMemory::~HighsMemory() {
+  }
+
+
+  Dict HighsInterface::get_stats(void* mem) const {
+    Dict stats = Conic::get_stats(mem);
+    Highs highs;
+    auto m = static_cast<HighsMemory*>(mem);
+    stats["return_status"] = highs.modelStatusToString(static_cast<HighsModelStatus>(m->return_status));
+    stats["simplex_iteration_count"] = m->simplex_iteration_count;
+    stats["simplex_iteration_count"] = m->simplex_iteration_count;
+    stats["ipm_iteration_count"] = m->ipm_iteration_count;
+    stats["qp_iteration_count"] = m->qp_iteration_count;
+    stats["crossover_iteration_count"] = m->crossover_iteration_count;
+    stats["primal_solution_status"]  = highs.solutionStatusToString(m->primal_solution_status);
+    stats["dual_solution_status"] = highs.solutionStatusToString(m->dual_solution_status);
+    stats["basis_validity"] = highs.basisValidityToString(m->basis_validity);
+    stats["mip_dual_bound"] = m->mip_dual_bound;
+    stats["mip_gap"] = m->mip_gap;
+    stats["num_primal_infeasibilities"] = m->num_primal_infeasibilities;
+    stats["max_primal_infeasibility"] = m->max_primal_infeasibility;
+    stats["sum_primal_infeasibilities"] = m->sum_primal_infeasibilities;
+    stats["num_dual_infeasibilities"] = m->num_dual_infeasibilities;
+    stats["max_dual_infeasibility"] = m->max_dual_infeasibility;
+    stats["sum_dual_infeasibilities"] = m->sum_dual_infeasibilities;
+    return stats;
+  }
+
+  HighsInterface::HighsInterface(DeserializingStream& s) : Conic(s) {
+    s.version("HighsInterface", 1);
+    s.unpack("HighsInterface::opts", opts_);
+  }
+
+  void HighsInterface::serialize_body(SerializingStream &s) const {
+    Conic::serialize_body(s);
+
+    s.version("HighsInterface", 1);
+    s.pack("HighsInterface::opts", opts_);
+  }
+
+} // end namespace casadi

--- a/casadi/interfaces/highs/highs_interface.hpp
+++ b/casadi/interfaces/highs/highs_interface.hpp
@@ -1,0 +1,156 @@
+/*
+ *    This file is part of CasADi.
+ *
+ *    CasADi -- A symbolic framework for dynamic optimization.
+ *    Copyright (C) 2010-2014 Joel Andersson, Joris Gillis, Moritz Diehl,
+ *                            K.U. Leuven. All rights reserved.
+ *    Copyright (C) 2011-2014 Greg Horn
+ *
+ *    CasADi is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation; either
+ *    version 3 of the License, or (at your option) any later version.
+ *
+ *    CasADi is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public
+ *    License along with CasADi; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef CASADI_HIGHS_INTERFACE_HPP
+#define CASADI_HIGHS_INTERFACE_HPP
+
+#include "casadi/core/conic_impl.hpp"
+#include <casadi/interfaces/highs/casadi_conic_highs_export.h>
+
+#include "Highs.h"
+#include <string>
+
+/** \defgroup plugin_Conic_highs
+
+      Interface to HiGHS solver for sparse Quadratic Programs,
+      see highs.dev for more information and
+      https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.html
+      for a list of options.
+*/
+
+/** \pluginsection{Conic,highs} */
+
+/// \cond INTERNAL
+
+namespace casadi {
+
+  struct CASADI_CONIC_HIGHS_EXPORT HighsMemory : public ConicMemory {
+    /// Constructor
+    HighsMemory();
+
+    /// Destructor
+    ~HighsMemory();
+
+    std::vector<int> colinda, rowa, colindh, rowh, integrality;
+
+    int return_status;
+
+    int simplex_iteration_count;
+    int ipm_iteration_count;
+    int qp_iteration_count;
+    int crossover_iteration_count;
+    int primal_solution_status;
+    int dual_solution_status;
+    int basis_validity;
+    double mip_dual_bound;
+    double mip_gap;
+    int num_primal_infeasibilities;
+    double max_primal_infeasibility;
+    double sum_primal_infeasibilities;
+    int num_dual_infeasibilities;
+    double max_dual_infeasibility;
+    double sum_dual_infeasibilities;
+
+  };
+
+  /** \brief \pluginbrief{Conic,highs}
+
+      @copydoc Highs_doc
+      @copydoc plugin_Conic_highs
+
+
+      \author Felix Lenders, Attila Kozma, Joel Andersson
+      \date 2021
+  */
+  class CASADI_CONIC_HIGHS_EXPORT HighsInterface : public Conic {
+  public:
+    /** \brief  Create a new QP Solver */
+    static Conic* creator(const std::string& name,
+                          const std::map<std::string, Sparsity>& st) {
+      return new HighsInterface(name, st);
+    }
+
+    /// Constructor using sparsity patterns
+    explicit HighsInterface(const std::string& name,
+                            const std::map<std::string, Sparsity>& st);
+
+    /// Destructor
+    ~HighsInterface() override;
+
+    // Get name of the plugin
+    const char* plugin_name() const override { return "highs";}
+
+    // Get name of the class
+    std::string class_name() const override { return "HighsInterface";}
+
+    ///@{
+    /** \brief Options */
+    static const Options options_;
+    const Options& get_options() const override { return options_;}
+    ///@}
+
+    // Initialize the solver
+    void init(const Dict& opts) override;
+
+    /** \brief Create memory block */
+    void* alloc_mem() const override { return new HighsMemory();}
+
+    /** \brief Initalize memory block */
+    int init_mem(void* mem) const override;
+
+    /** \brief Free memory block */
+    void free_mem(void *mem) const override { delete static_cast<HighsMemory*>(mem);}
+
+    /// Get all statistics
+    Dict get_stats(void* mem) const override;
+
+    // Solve the QP
+    int solve(const double** arg, double** res,
+      casadi_int* iw, double* w, void* mem) const override;
+
+    /// A documentation string
+    static const std::string meta_doc;
+
+    /// All HiGHS options
+    Dict opts_;
+
+    void serialize_body(SerializingStream &s) const override;
+
+    /** \brief Deserialize with type disambiguation */
+    static ProtoFunction* deserialize(DeserializingStream& s) { return new HighsInterface(s); }
+
+    /// Can discrete variables be treated
+    bool integer_support() const override { return true; }
+
+  protected:
+     /** \brief Deserializing constructor */
+    explicit HighsInterface(DeserializingStream& s);
+
+  private:
+    static std::list<std::string> param_bool;
+
+  };
+} // end namespace casadi
+/// \endcond
+#endif // CASADI_HIGHS_INTERFACE_HPP

--- a/casadi/interfaces/highs/highs_interface_meta.cpp
+++ b/casadi/interfaces/highs/highs_interface_meta.cpp
@@ -1,0 +1,31 @@
+/*
+ *    This file is part of CasADi.
+ *
+ *    CasADi -- A symbolic framework for dynamic optimization.
+ *    Copyright (C) 2010-2014 Joel Andersson, Joris Gillis, Moritz Diehl,
+ *                            K.U. Leuven. All rights reserved.
+ *    Copyright (C) 2011-2014 Greg Horn
+ *
+ *    CasADi is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation; either
+ *    version 3 of the License, or (at your option) any later version.
+ *
+ *    CasADi is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public
+ *    License along with CasADi; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+
+      #include "highs_interface.hpp"
+      #include <string>
+
+      const std::string casadi::HighsInterface::meta_doc=
+      "\n"
+      ;

--- a/cmake/FindHIGHS.cmake
+++ b/cmake/FindHIGHS.cmake
@@ -1,0 +1,24 @@
+# Get package info using pkg-config
+find_package(PkgConfig)
+pkg_search_module(HIGHS highs)
+
+include(canonicalize_paths)
+canonicalize_paths(HIGHS_LIBRARY_DIRS)
+
+# add osx frameworks to CBC_LIBRARIES
+#if(CBC_LIBRARIES)
+#  if(APPLE)
+#    # turn "-framework;foo;-framework;bar;other" into "-framework foo;-framework bar;other"
+#    string(REPLACE "-framework;" "-framework " CBC_LDFLAGS_OTHER "${CBC_LDFLAGS_OTHER}")
+#    # take "-framework foo;-framework bar;other" and add only frameworks to CBC_LIBRARIES
+#    foreach(arg ${CBC_LDFLAGS_OTHER})
+#      if("${arg}" MATCHES "-framework .+")
+#        set(CBC_LIBRARIES "${CBC_LIBRARIES};${arg}")
+#      endif("${arg}" MATCHES "-framework .+")
+#    endforeach(arg ${CBC_LDFLAGS_OTHER})
+#  endif(APPLE)
+#endif(CBC_LIBRARIES)
+
+# Set standard flags
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HIGHS DEFAULT_MSG HIGHS_LIBRARIES HIGHS_INCLUDE_DIRS)


### PR DESCRIPTION
As discussed in #2851 PR for HiGHS that is running for me with sample LP, MILP and QP. I continue the discussion from the issue here, some open points / ToDo:

- The interface accepts an MIQP and passes this to HiGHS, in the case of MIQP HiGHS silently ignores integrality on the variables and solves the QP relaxation. I hope this changes in the future and for this reason am not catching it in the interface. Should we issue a warning?
- Output: As already discussed in the issue, HiGHS can only redirect output to a file, not to a stream given the current interface. I left output that with stdout. Also HiGHS is at the moment creating an empty file `Highs.log`, there is already an [issue](https://github.com/ERGO-Code/HiGHS/issues/586) for this.
- Active Set: HiGHS is has alternatives to solve LP with either simplex or interior point and has an experimental crossover from interior point to simplex. So yes, an active set can be obtained from HiGHS. Is there an example I can use to see how you interface this, then I am happy to add the active set to the interface.
- Hotstarting: HiGHS supports hotstarting, most easily if the full model is retained and data of the model is changed. As an alternative after a run the basis information can be copied and set before the next run on a new model. None of this is present in the interface, but I am also happy to look into this if you can point me to a blueprint on hot start interfacing.
- CMake: I have used the CBC interface code as starter and but commented out two blocks that apply for clang or Apple. I have not tested with these platforms, so not sure if they are necessary.
- External Submodule / Building: I have not yet included highs as external submodule into the casadi repository, but am happy to do so if you can point an example so that I can see how to integrate it into the build chain.