### PR TITLE
Since LLVM 10, the CreateFromArgs interface changed

### DIFF
--- a/casadi/interfaces/clang/clang_compiler.cpp
+++ b/casadi/interfaces/clang/clang_compiler.cpp
@@ -158,8 +158,11 @@ namespace casadi {
     #else
     clang::CompilerInvocation* compInv = new clang::CompilerInvocation();
     #endif
-    clang::CompilerInvocation::CreateFromArgs(*compInv, &args[0],
-                                              &args[0] + args.size(), diags);
+    #if LLVM_VERSION_MAJOR>=10
+    clang::CompilerInvocation::CreateFromArgs(*compInv, args, diags);
+    #else
+    clang::CompilerInvocation::CreateFromArgs(*compInv, &args[0], &args0] + args.size(), diags);
+    #endif
     compInst.setInvocation(compInv);
 
     // Get ready to report problems


### PR DESCRIPTION
When using the latest LLVM + CLang on ubuntu, the CreateFromArgs interface doesn't work due to a change traced back to this commit:

https://github.com/llvm-mirror/clang/commit/610ec02d6d37fe332e142d131378545b41db879d

It is first present in LLVM version 10. This version however has some problems with ubuntu 20.04. Using llvm 12.0.1 & clang 12.0.1 (setup using https://www.linuxfromscratch.org/blfs/view/11.0-systemd/general/llvm.html ), it works nicely.