### PR TITLE
Simple LDL^T solve interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ obj-x86_64-linux-gnu
 *.so
 *.orig
 *.swp
+.cache
 
 test/python/*.c
 

--- a/casadi/core/matrix_decl.hpp
+++ b/casadi/core/matrix_decl.hpp
@@ -448,6 +448,7 @@ namespace casadi {
                     std::vector<casadi_int>& p, bool amd=true);
     static Matrix<Scalar> ldl_solve(const Matrix<Scalar>& b, const Matrix<Scalar>& D,
                                     const Matrix<Scalar>& LT, const std::vector<casadi_int>& p);
+    static Matrix<Scalar> ldl_solve(const Matrix<Scalar>& A, const Matrix<Scalar>& b);
     static Matrix<Scalar> all(const Matrix<Scalar>& x);
     static Matrix<Scalar> any(const Matrix<Scalar>& x);
     static Matrix<Scalar> adj(const Matrix<Scalar>& x);
@@ -539,6 +540,12 @@ namespace casadi {
     ldl_solve(const Matrix<Scalar>& b, const Matrix<Scalar>& D, const Matrix<Scalar>& LT,
               const std::vector<casadi_int>& p) {
       return Matrix<Scalar>::ldl_solve(b, D, LT, p);
+    }
+
+    /** \brief Perform LDL^T factorization of A and then solve Ax=b for x */
+    friend inline Matrix<Scalar>
+    ldl_solve(const Matrix<Scalar>& A, const Matrix<Scalar>& b) {
+      return Matrix<Scalar>::ldl_solve(A, b);
     }
 
     /** \brief Returns true only if any element in the matrix is true

--- a/casadi/core/matrix_impl.hpp
+++ b/casadi/core/matrix_impl.hpp
@@ -2093,6 +2093,16 @@ namespace casadi {
   }
 
   template<typename Scalar>
+  Matrix<Scalar> Matrix<Scalar>::
+  ldl_solve(const Matrix<Scalar>& A, const Matrix<Scalar>& b) {
+    // Perform an LDL transformation
+    Matrix<Scalar> D, LT;
+    std::vector<casadi_int> p;
+    ldl(A, D, LT, p, false);
+    return ldl_solve(b, D, LT, p);
+  }
+
+  template<typename Scalar>
   Matrix<Scalar> Matrix<Scalar>::nullspace(const Matrix<Scalar>& A) {
     Matrix<Scalar> X = A;
     casadi_int n = X.size1();


### PR DESCRIPTION
## What?
This pull request aims to simplify the interface to solving a linear system via LDL^T factorization (https://en.wikipedia.org/wiki/Cholesky_decomposition).
I overloaded the preexisting "ldl_solve" function to accept just "A" and "b" and return the solution to the linear system "Ax=b".

## Why?
Marginally simplify the interface to the "ldl_solve" function. Currently, one must write code like this:

// matrix "A" and column vector "b" already defined
casadi::SX D, LT;  // or casadi::DM type
std::vector<casadi_int> p;
ldl(A, D, LT, p, false);
auto x = ldl_solve(b, D, LT, p);

The Eigen library has a more concise interface (https://eigen.tuxfamily.org/dox/group__TutorialLinearAlgebra.html):

auto x = A.ldlt().solve(b)

This pull request will allow a user to call "ldl_solve" like this:

auto x = ldl_solve(A, b);