### PR TITLE
Fix MSYS2 Windows build

### DIFF
--- a/casadi/core/binary_mx_impl.hpp
+++ b/casadi/core/binary_mx_impl.hpp
@@ -33,7 +33,6 @@
 #include <sstream>
 #include <vector>
 
-using namespace std;
 
 namespace casadi {
 
@@ -122,9 +121,9 @@ namespace casadi {
     }
 
     // Scalar names of arguments (start assuming all scalars)
-    string r = g.workel(res[0]);
-    string x = g.workel(arg[0]);
-    string y = g.workel(arg[1]);
+    std::string r = g.workel(res[0]);
+    std::string x = g.workel(arg[0]);
+    std::string y = g.workel(arg[1]);
 
     // Avoid emitting '/*' which will be mistaken for a comment
     if (op_==OP_DIV && g.codegen_scalars && dep(1).nnz()==1) {

--- a/casadi/core/setnonzeros_impl.hpp
+++ b/casadi/core/setnonzeros_impl.hpp
@@ -32,7 +32,6 @@
 
 /// \cond INTERNAL
 
-using namespace std;
 
 namespace casadi {
 
@@ -40,7 +39,7 @@ namespace casadi {
   MX SetNonzeros<Add>::create(const MX& y, const MX& x, const std::vector<casadi_int>& nz) {
     if (is_slice(nz)) return create(y, x, to_slice(nz));
     if (is_slice2(nz)) {
-      pair<Slice, Slice> sl = to_slice2(nz);
+      std::pair<Slice, Slice> sl = to_slice2(nz);
       return create(y, x, sl.first, sl.second);
     }
     return MX::create(new SetNonzerosVector<Add>(y, x, nz));
@@ -75,8 +74,8 @@ namespace casadi {
       const std::vector<casadi_int>& nz) : SetNonzeros<Add>(y, x), nz_(nz) {
     // Ignore duplicate assignments
     if (!Add) {
-      vector<bool> already_set(this->nnz(), false);
-      for (vector<casadi_int>::reverse_iterator i=nz_.rbegin(); i!=nz_.rend(); ++i) {
+     std::vector<bool> already_set(this->nnz(), false);
+      for (std::vector<casadi_int>::reverse_iterator i=nz_.rbegin(); i!=nz_.rend(); ++i) {
         if (*i>=0) {
           if (already_set[*i]) {
             *i = -1;
@@ -95,21 +94,21 @@ namespace casadi {
   template<bool Add>
   void SetNonzeros<Add>::eval_mx(const std::vector<MX>& arg, std::vector<MX>& res) const {
     // Get all the nonzeros
-    vector<casadi_int> nz = all();
+    std::vector<casadi_int> nz = all();
 
     // Output sparsity
     const Sparsity &osp = sparsity();
     const casadi_int* orow = osp.row();
-    vector<casadi_int> ocol = osp.get_col();
+    std::vector<casadi_int> ocol = osp.get_col();
 
     // Input sparsity (first input same as output)
     const Sparsity &isp = dep(1).sparsity();
-    vector<casadi_int> icol = isp.get_col();
+    std::vector<casadi_int> icol = isp.get_col();
 
-    // We next need to resort the assignment vector by outputs instead of inputs
+    // We next need to resort the assignment std::vector by outputs instead of inputs
     // Start by counting the number of output nonzeros corresponding to each input nonzero
-    vector<casadi_int> onz_count(osp.nnz()+2, 0);
-    for (vector<casadi_int>::const_iterator it=nz.begin(); it!=nz.end(); ++it) {
+    std::vector<casadi_int> onz_count(osp.nnz()+2, 0);
+    for (std::vector<casadi_int>::const_iterator it=nz.begin(); it!=nz.end(); ++it) {
       onz_count[*it+2]++;
     }
 
@@ -119,14 +118,14 @@ namespace casadi {
     }
 
     // Get the order of assignments
-    vector<casadi_int> nz_order(nz.size());
+    std::vector<casadi_int> nz_order(nz.size());
     for (casadi_int k=0; k<nz.size(); ++k) {
       // Save the new index
       nz_order[onz_count[1+nz[k]]++] = k;
     }
 
     // Find out which elements are being set
-    vector<casadi_int>& with_duplicates = onz_count; // Reuse memory
+    std::vector<casadi_int>& with_duplicates = onz_count; // Reuse memory
     onz_count.resize(nz.size());
     for (casadi_int k=0; k<nz.size(); ++k) {
       // Get output nonzero
@@ -141,11 +140,11 @@ namespace casadi {
     }
 
     // Get all output elements (this time without duplicates)
-    vector<casadi_int> el_output;
+    std::vector<casadi_int> el_output;
     osp.find(el_output);
 
     // Sparsity pattern being formed and corresponding nonzero mapping
-    vector<casadi_int> r_colind, r_row, r_nz, r_ind;
+    std::vector<casadi_int> r_colind, r_row, r_nz, r_ind;
 
     // Get references to arguments and results
     res[0] = arg[0];
@@ -155,7 +154,7 @@ namespace casadi {
 
       // Get the nz locations in res corresponding to the output sparsity pattern
       r_nz.resize(with_duplicates.size());
-      copy(with_duplicates.begin(), with_duplicates.end(), r_nz.begin());
+      std::copy(with_duplicates.begin(), with_duplicates.end(), r_nz.begin());
       res[0].sparsity().get_nz(r_nz);
 
       // Zero out the corresponding entries
@@ -168,7 +167,7 @@ namespace casadi {
 
     // Filter out ignored entries and check if there is anything to add at all
     bool elements_to_add = false;
-    for (vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
+    for (std::vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
       if (*k>=0) {
         if (nz[*k]>=0) {
           elements_to_add = true;
@@ -183,11 +182,11 @@ namespace casadi {
 
     // Get the nz locations in the argument corresponding to the inputs
     r_ind.resize(el_output.size());
-    copy(el_output.begin(), el_output.end(), r_ind.begin());
+    std::copy(el_output.begin(), el_output.end(), r_ind.begin());
     res[0].sparsity().get_nz(r_ind);
 
     // Enlarge the sparsity pattern of the arguments if not all assignments fit
-    for (vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
+    for (std::vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
       if (*k>=0 && nz[*k]>=0 && r_ind[nz[*k]]<0) {
 
         // Create a new pattern which includes both the the previous seed
@@ -196,7 +195,7 @@ namespace casadi {
         res[0] = res[0]->get_project(sp);
 
         // Recalculate the nz locations in the arguments corresponding to the inputs
-        copy(el_output.begin(), el_output.end(), r_ind.begin());
+        std::copy(el_output.begin(), el_output.end(), r_ind.begin());
         res[0].sparsity().get_nz(r_ind);
 
         break;
@@ -204,7 +203,7 @@ namespace casadi {
     }
 
     // Have r_nz point to locations in the result instead of the output
-    for (vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
+    for (std::vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
       if (*k>=0) {
         *k = r_ind[nz[*k]];
       }
@@ -218,7 +217,7 @@ namespace casadi {
   void SetNonzeros<Add>::ad_forward(const std::vector<std::vector<MX> >& fseed,
                                  std::vector<std::vector<MX> >& fsens) const {
     // Get all the nonzeros
-    vector<casadi_int> nz = all();
+    std::vector<casadi_int> nz = all();
 
     // Number of derivative directions
     casadi_int nfwd = fsens.size();
@@ -226,26 +225,26 @@ namespace casadi {
     // Output sparsity
     const Sparsity &osp = sparsity();
     const casadi_int* orow = osp.row();
-    vector<casadi_int> ocol;
+    std::vector<casadi_int> ocol;
 
     // Input sparsity (first input same as output)
     const Sparsity &isp = dep(1).sparsity();
-    vector<casadi_int> icol;
+    std::vector<casadi_int> icol;
 
     bool first_run = true;
 
-    vector<casadi_int> onz_count;
+    std::vector<casadi_int> onz_count;
 
-    vector<casadi_int> nz_order;
+    std::vector<casadi_int> nz_order;
 
     // Find out which elements are being set
-    vector<casadi_int>& with_duplicates = onz_count;
+    std::vector<casadi_int>& with_duplicates = onz_count;
 
     // Get all output elements (this time without duplicates)
-    vector<casadi_int> el_output;
+    std::vector<casadi_int> el_output;
 
     // Sparsity pattern being formed and corresponding nonzero mapping
-    vector<casadi_int> r_colind, r_row, r_nz, r_ind;
+    std::vector<casadi_int> r_colind, r_row, r_nz, r_ind;
 
     // Nondifferentiated function and forward sensitivities
     for (casadi_int d=0; d<nfwd; ++d) {
@@ -281,10 +280,10 @@ namespace casadi {
           ocol = osp.get_col();
           icol = isp.get_col();
 
-          // We next need to resort the assignment vector by outputs instead of inputs
+          // We next need to resort the assignmentstd::vector by outputs instead of inputs
           // Start by counting the number of output nonzeros corresponding to each input nonzero
           onz_count.resize(osp.nnz()+2, 0);
-          for (vector<casadi_int>::const_iterator it=nz.begin(); it!=nz.end(); ++it) {
+          for (std::vector<casadi_int>::const_iterator it=nz.begin(); it!=nz.end(); ++it) {
             onz_count[*it+2]++;
           }
 
@@ -322,7 +321,7 @@ namespace casadi {
 
           // Get the nz locations in res corresponding to the output sparsity pattern
           r_nz.resize(with_duplicates.size());
-          copy(with_duplicates.begin(), with_duplicates.end(), r_nz.begin());
+          std::copy(with_duplicates.begin(), with_duplicates.end(), r_nz.begin());
           res.sparsity().get_nz(r_nz);
 
           // Zero out the corresponding entries
@@ -336,7 +335,7 @@ namespace casadi {
 
         // Filter out ignored entries and check if there is anything to add at all
         bool elements_to_add = false;
-        for (vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
+        for (std::vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
           if (*k>=0) {
             if (nz[*k]>=0) {
               elements_to_add = true;
@@ -351,11 +350,11 @@ namespace casadi {
 
         // Get the nz locations in the argument corresponding to the inputs
         r_ind.resize(el_output.size());
-        copy(el_output.begin(), el_output.end(), r_ind.begin());
+        std::copy(el_output.begin(), el_output.end(), r_ind.begin());
         res.sparsity().get_nz(r_ind);
 
         // Enlarge the sparsity pattern of the arguments if not all assignments fit
-        for (vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
+        for (std::vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
           if (*k>=0 && nz[*k]>=0 && r_ind[nz[*k]]<0) {
 
             // Create a new pattern which includes both the the previous seed
@@ -364,7 +363,7 @@ namespace casadi {
             res = res->get_project(sp);
 
             // Recalculate the nz locations in the arguments corresponding to the inputs
-            copy(el_output.begin(), el_output.end(), r_ind.begin());
+            std::copy(el_output.begin(), el_output.end(), r_ind.begin());
             res.sparsity().get_nz(r_ind);
 
             break;
@@ -372,7 +371,7 @@ namespace casadi {
         }
 
         // Have r_nz point to locations in the result instead of the output
-        for (vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
+        for (std::vector<casadi_int>::iterator k=r_nz.begin(); k!=r_nz.end(); ++k) {
           if (*k>=0) {
             *k = r_ind[nz[*k]];
           }
@@ -388,7 +387,7 @@ namespace casadi {
   void SetNonzeros<Add>::ad_reverse(const std::vector<std::vector<MX> >& aseed,
                                  std::vector<std::vector<MX> >& asens) const {
     // Get all the nonzeros
-    vector<casadi_int> nz = all();
+    std::vector<casadi_int> nz = all();
 
     // Number of derivative directions
     casadi_int nadj = aseed.size();
@@ -396,27 +395,27 @@ namespace casadi {
     // Output sparsity
     const Sparsity &osp = sparsity();
     const casadi_int* orow = osp.row();
-    vector<casadi_int> ocol;
+    std::vector<casadi_int> ocol;
 
     // Input sparsity (first input same as output)
     const Sparsity &isp = dep(1).sparsity();
     const casadi_int* irow = isp.row();
-    vector<casadi_int> icol;
+    std::vector<casadi_int> icol;
 
-    vector<casadi_int> onz_count;
+    std::vector<casadi_int> onz_count;
 
     // Get the order of assignments
-    vector<casadi_int> nz_order;
+    std::vector<casadi_int> nz_order;
 
-    vector<casadi_int>& with_duplicates = onz_count; // Reuse memory
+    std::vector<casadi_int>& with_duplicates = onz_count; // Reuse memory
 
     // Get all output elements (this time without duplicates)
-    vector<casadi_int> el_output;
+    std::vector<casadi_int> el_output;
 
     bool first_run = true;
 
     // Sparsity pattern being formed and corresponding nonzero mapping
-    vector<casadi_int> r_colind, r_row, r_nz, r_ind;
+    std::vector<casadi_int> r_colind, r_row, r_nz, r_ind;
 
     for (casadi_int d=0; d<nadj; ++d) {
       if (osp==aseed[d][0].sparsity()) {
@@ -439,10 +438,10 @@ namespace casadi {
         if (first_run) {
           ocol = osp.get_col();
           icol = isp.get_col();
-          // We next need to resort the assignment vector by outputs instead of inputs
+          // We next need to resort the assignment std::vector by outputs instead of inputs
           // Start by counting the number of output nonzeros corresponding to each input nonzero
           onz_count.resize(osp.nnz()+2, 0);
-          for (vector<casadi_int>::const_iterator it=nz.begin(); it!=nz.end(); ++it) {
+          for (std::vector<casadi_int>::const_iterator it=nz.begin(); it!=nz.end(); ++it) {
             onz_count[*it+2]++;
           }
 
@@ -478,7 +477,7 @@ namespace casadi {
 
         // Get the matching nonzeros
         r_ind.resize(el_output.size());
-        copy(el_output.begin(), el_output.end(), r_ind.begin());
+        std::copy(el_output.begin(), el_output.end(), r_ind.begin());
         aseed[d][0].sparsity().get_nz(r_ind);
 
         // Sparsity pattern for the result
@@ -518,7 +517,7 @@ namespace casadi {
 
         // If anything to set/add
         if (!r_nz.empty()) {
-          // Create a sparsity pattern from vectors
+          // Create a sparsity pattern from std::vectors
           Sparsity f_sp(isp.size1(), isp.size2(), r_colind, r_row);
           asens[d][1] += aseed[d][0]->get_nzref(f_sp, r_nz);
           if (!Add) {
@@ -553,9 +552,9 @@ namespace casadi {
     const T* idata = arg[1];
     T* odata = res[0];
     if (idata0 != odata) {
-      copy(idata0, idata0+this->dep(0).nnz(), odata);
+      std::copy(idata0, idata0+this->dep(0).nnz(), odata);
     }
-    for (vector<casadi_int>::const_iterator k=this->nz_.begin(); k!=this->nz_.end(); ++k, ++idata) {
+    for (std::vector<casadi_int>::const_iterator k=this->nz_.begin(); k!=this->nz_.end(); ++k, ++idata) {
       if (Add) {
         if (*k>=0) odata[*k] += *idata;
       } else {
@@ -585,7 +584,7 @@ namespace casadi {
     const T* idata = arg[1];
     T* odata = res[0];
     if (idata0 != odata) {
-      copy(idata0, idata0+this->dep(0).nnz(), odata);
+      std::copy(idata0, idata0+this->dep(0).nnz(), odata);
     }
     T* odata_stop = odata + s_.stop;
     for (odata += s_.start; odata != odata_stop; odata += s_.step) {
@@ -618,7 +617,7 @@ namespace casadi {
     const T* idata = arg[1];
     T* odata = res[0];
     if (idata0 != odata) {
-      copy(idata0, idata0 + this->dep(0).nnz(), odata);
+      std::copy(idata0, idata0 + this->dep(0).nnz(), odata);
     }
     T* outer_stop = odata + outer_.stop;
     T* outer = odata + outer_.start;
@@ -645,8 +644,8 @@ namespace casadi {
     casadi_int n = this->nnz();
 
     // Propagate sparsity
-    if (r != a0) copy(a0, a0+n, r);
-    for (vector<casadi_int>::const_iterator k=this->nz_.begin(); k!=this->nz_.end(); ++k, ++a) {
+    if (r != a0) std::copy(a0, a0+n, r);
+    for (std::vector<casadi_int>::const_iterator k=this->nz_.begin(); k!=this->nz_.end(); ++k, ++a) {
       if (Add) {
         if (*k>=0) r[*k] |= *a;
       } else {
@@ -661,7 +660,7 @@ namespace casadi {
   sp_reverse(bvec_t** arg, bvec_t** res, casadi_int* iw, bvec_t* w) const {
     bvec_t *a = arg[1];
     bvec_t *r = res[0];
-    for (vector<casadi_int>::const_iterator k=this->nz_.begin(); k!=this->nz_.end(); ++k, ++a) {
+    for (std::vector<casadi_int>::const_iterator k=this->nz_.begin(); k!=this->nz_.end(); ++k, ++a) {
       if (*k>=0) {
         *a |= r[*k];
         if (!Add) {
@@ -682,7 +681,7 @@ namespace casadi {
     casadi_int n = this->nnz();
 
     // Propagate sparsity
-    if (r != a0) copy(a0, a0+n, r);
+    if (r != a0) std::copy(a0, a0+n, r);
     for (casadi_int k=s_.start; k!=s_.stop; k+=s_.step) {
       if (Add) {
         r[k] |= *a++;
@@ -717,7 +716,7 @@ namespace casadi {
     casadi_int n = this->nnz();
 
     // Propagate sparsity
-    if (r != a0) copy(a0, a0+n, r);
+    if (r != a0) std::copy(a0, a0+n, r);
     for (casadi_int k1=outer_.start; k1!=outer_.stop; k1+=outer_.step) {
       for (casadi_int k2=k1+inner_.start; k2!=k1+inner_.stop; k2+=inner_.step) {
         if (Add) {
@@ -749,21 +748,21 @@ namespace casadi {
 
   template<bool Add>
   std::string SetNonzerosVector<Add>::disp(const std::vector<std::string>& arg) const {
-    stringstream ss;
+    std::stringstream ss;
     ss << "(" << arg.at(0) << nz_ << (Add ? " += " : " = ") << arg.at(1) << ")";
     return ss.str();
   }
 
   template<bool Add>
   std::string SetNonzerosSlice<Add>::disp(const std::vector<std::string>& arg) const {
-    stringstream ss;
+    std::stringstream ss;
     ss << "(" << arg.at(0) << "[" << s_ << "]" << (Add ? " += " : " = ") << arg.at(1) << ")";
     return ss.str();
   }
 
   template<bool Add>
   std::string SetNonzerosSlice2<Add>::disp(const std::vector<std::string>& arg) const {
-    stringstream ss;
+    std::stringstream ss;
     ss << "(" << arg.at(0) << "[" << outer_ << ";" << inner_ << "]" << (Add ? " += " : " = ")
        << arg.at(1) << ")";
     return ss.str();
@@ -771,7 +770,7 @@ namespace casadi {
 
   template<bool Add>
   Matrix<casadi_int> SetNonzeros<Add>::mapping() const {
-    vector<casadi_int> nz = all();
+    std::vector<casadi_int> nz = all();
     return Matrix<casadi_int>(this->dep(1).sparsity(), nz, false);
   }
 

--- a/casadi/core/setnonzeros_param_impl.hpp
+++ b/casadi/core/setnonzeros_param_impl.hpp
@@ -32,7 +32,6 @@
 
 /// \cond INTERNAL
 
-using namespace std;
 
 namespace casadi {
 
@@ -313,7 +312,7 @@ namespace casadi {
     casadi_int nnz = this->dep(2).nnz();
     casadi_int max_ind = this->dep(0).nnz();
     if (idata0 != odata) {
-      copy(idata0, idata0+this->dep(0).nnz(), odata);
+      std::copy(idata0, idata0+this->dep(0).nnz(), odata);
     }
     for (casadi_int k=0; k<nnz; ++k) {
       // Get index
@@ -339,7 +338,7 @@ namespace casadi {
     casadi_int nnz = this->dep(2).nnz();
     casadi_int max_ind = this->dep(0).nnz();
     if (idata0 != odata) {
-      copy(idata0, idata0+this->dep(0).nnz(), odata);
+      std::copy(idata0, idata0+this->dep(0).nnz(), odata);
     }
 
     casadi_int* inner = iw; iw += nnz;
@@ -373,7 +372,7 @@ namespace casadi {
     casadi_int nnz = this->dep(2).nnz();
     casadi_int max_ind = this->dep(0).nnz();
     if (idata0 != odata) {
-      copy(idata0, idata0+this->dep(0).nnz(), odata);
+      std::copy(idata0, idata0+this->dep(0).nnz(), odata);
     }
     for (casadi_int k=0; k<nnz; ++k) {
       // Get index
@@ -404,7 +403,7 @@ namespace casadi {
     casadi_int nnz2 = this->dep(3).nnz();
     casadi_int max_ind = this->dep(0).nnz();
     if (idata0 != odata) {
-      copy(idata0, idata0+this->dep(0).nnz(), odata);
+      std::copy(idata0, idata0+this->dep(0).nnz(), odata);
     }
 
     casadi_int* inner = iw; iw += nnz;
@@ -473,7 +472,7 @@ namespace casadi {
 
   template<bool Add>
   std::string SetNonzerosParamVector<Add>::disp(const std::vector<std::string>& arg) const {
-    stringstream ss;
+    std::stringstream ss;
     ss << "(" << arg.at(0) << "[" << arg.at(2) << "]";
     ss << (Add ? " += " : " = ") << arg.at(1) << ")";
     return ss.str();
@@ -481,7 +480,7 @@ namespace casadi {
 
   template<bool Add>
   std::string SetNonzerosParamSlice<Add>::disp(const std::vector<std::string>& arg) const {
-    stringstream ss;
+    std::stringstream ss;
     ss << "(" << arg.at(0) << "[(" << arg.at(2) << ";" << outer_ << ")]";
     ss << (Add ? " += " : " = ") << arg.at(1) << ")";
     return ss.str();
@@ -489,7 +488,7 @@ namespace casadi {
 
   template<bool Add>
   std::string SetNonzerosSliceParam<Add>::disp(const std::vector<std::string>& arg) const {
-    stringstream ss;
+    std::stringstream ss;
     ss << "(" << arg.at(0) << "[(" << inner_ << ";" << arg.at(2) << ")]";
     ss << (Add ? " += " : " = ") << arg.at(1) << ")";
     return ss.str();
@@ -497,7 +496,7 @@ namespace casadi {
 
   template<bool Add>
   std::string SetNonzerosParamParam<Add>::disp(const std::vector<std::string>& arg) const {
-    stringstream ss;
+    std::stringstream ss;
     ss << "(" << arg.at(0) << "[(" << arg.at(2) << ";" << arg.at(3) << ")]";
     ss << (Add ? " += " : " = ") << arg.at(1) << ")";
     return ss.str();

--- a/casadi/core/solve_impl.hpp
+++ b/casadi/core/solve_impl.hpp
@@ -29,7 +29,6 @@
 #include "solve.hpp"
 #include "linsol_internal.hpp"
 
-using namespace std;
 
 namespace casadi {
 
@@ -53,7 +52,7 @@ namespace casadi {
 
   template<bool Tr>
   int Solve<Tr>::eval(const double** arg, double** res, casadi_int* iw, double* w) const {
-    if (arg[0]!=res[0]) copy(arg[0], arg[0]+dep(0).nnz(), res[0]);
+    if (arg[0]!=res[0]) std::copy(arg[0], arg[0]+dep(0).nnz(), res[0]);
     scoped_checkout<Linsol> mem(linsol_);
 
     auto m = static_cast<LinsolMemory*>(linsol_->memory(mem));
@@ -89,9 +88,9 @@ namespace casadi {
   void Solve<Tr>::ad_forward(const std::vector<std::vector<MX> >& fseed,
                           std::vector<std::vector<MX> >& fsens) const {
     // Nondifferentiated inputs and outputs
-    vector<MX> arg(n_dep());
+    std::vector<MX> arg(n_dep());
     for (casadi_int i=0; i<arg.size(); ++i) arg[i] = dep(i);
-    vector<MX> res(nout());
+    std::vector<MX> res(nout());
     for (casadi_int i=0; i<res.size(); ++i) res[i] = get_output(i);
 
     // Number of derivatives
@@ -122,9 +121,9 @@ namespace casadi {
   void Solve<Tr>::ad_reverse(const std::vector<std::vector<MX> >& aseed,
                           std::vector<std::vector<MX> >& asens) const {
     // Nondifferentiated inputs and outputs
-    vector<MX> arg(n_dep());
+    std::vector<MX> arg(n_dep());
     for (casadi_int i=0; i<arg.size(); ++i) arg[i] = dep(i);
-    vector<MX> res(nout());
+    std::vector<MX> res(nout());
     for (casadi_int i=0; i<res.size(); ++i) res[i] = get_output(i);
 
     // Number of derivatives
@@ -186,8 +185,8 @@ namespace casadi {
 
     // For all right-hand-sides
     for (casadi_int r=0; r<nrhs; ++r) {
-      // Copy B to a temporary vector
-      copy(B, B+n, tmp);
+      // Copy B to a temporary std::vector
+      std::copy(B, B+n, tmp);
 
       // Add A_hat contribution to tmp
       for (casadi_int cc=0; cc<n; ++cc) {


### PR DESCRIPTION
Removed using namespace std; from header files as it can be populated into
other header files creating namespace ambiguity e.g. for byte type

Fix for issue
 #2945