### PR TITLE
Add casadi_ prefix to namespace of internal qpOASES fork

### DIFF
--- a/casadi/interfaces/qpoases/qpoases_interface.hpp
+++ b/casadi/interfaces/qpoases/qpoases_interface.hpp
@@ -31,6 +31,8 @@
 #include <casadi/interfaces/qpoases/casadi_conic_qpoases_export.h>
 #include <qpOASES.hpp>
 
+namespace qpOASES = casadi_qpOASES; 
+
 /** \defgroup plugin_Conic_qpoases Title
     \par
 

--- a/external_packages/qpOASES/include/qpOASES/Types.hpp
+++ b/external_packages/qpOASES/include/qpOASES/Types.hpp
@@ -104,16 +104,16 @@
 #else
 
     /** Macro for switching on/off the beginning of the qpOASES namespace definition. */
-    #define BEGIN_NAMESPACE_QPOASES  namespace qpOASES {
+    #define BEGIN_NAMESPACE_QPOASES  namespace casadi_qpOASES {
 
     /** Macro for switching on/off the end of the qpOASES namespace definition. */
     #define END_NAMESPACE_QPOASES    }
 
     /** Macro for switching on/off the use of the qpOASES namespace. */
-    #define USING_NAMESPACE_QPOASES  using namespace qpOASES;
+    #define USING_NAMESPACE_QPOASES  using namespace casadi_qpOASES;
 
     /** Macro for switching on/off references to the qpOASES namespace. */
-    #define REFER_NAMESPACE_QPOASES  qpOASES::
+    #define REFER_NAMESPACE_QPOASES  casadi_qpOASES::
 
 #endif
 


### PR DESCRIPTION
`casadi` contains a modified fork of qpOASES with a different ABI and API w.r.t. to the upstream qpOASES. To avoid ABI incompatibilities at runtime between the qpOASES and casadi_qpOASES symbols , this PR adds a `casadi_` prefix to the `qpOASES` namespace in the fork, to ensure that the symbols of casadi_qpOASES  and the symbols of qpOASES will have different names.

See https://github.com/simbody/simbody/issues/510 for a similar issue in a different project, and https://github.com/conda-forge/casadi-feedstock/issues/75 for the downstream issue.