### PR TITLE
Fix compilation of WITH_OSQP=ON and WITH_BUILD_OSQP=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1482,6 +1482,9 @@ if(WITH_OSQP)
         CMAKE_ARGS -DCMAKE_C_STANDARD_REQUIRED=TRUE -DCMAKE_C_STANDARD=99 -DENABLE_MKL_PARDISO=OFF -DPROFILING=OFF -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>)
     file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/external_projects/include/osqp")
     add_library(osqp SHARED IMPORTED)
+    # This is similar to ALIAS but works fine on imported targets with CMake 3.10
+    add_library(osqp::osqp INTERFACE IMPORTED)
+    set_target_properties(osqp::osqp PROPERTIES INTERFACE_LINK_LIBRARIES osqp)
     add_dependencies(osqp osqp-external)
     set_target_properties(osqp PROPERTIES
        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/external_projects/include/osqp"

--- a/casadi/interfaces/osqp/CMakeLists.txt
+++ b/casadi/interfaces/osqp/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)
 
-option(USE_SYSTEM_WISE_OSQP "Use a systemwise installation of osqp" OFF)
-
 include_directories(../)
 
 casadi_plugin(Conic osqp
@@ -9,13 +7,7 @@ casadi_plugin(Conic osqp
   osqp_interface.cpp
   osqp_interface_meta.cpp)
 
-# Add the possibility to use a systemwise installation of casadi
-if(USE_SYSTEM_WISE_OSQP)
-  find_package(osqp REQUIRED)
-  casadi_plugin_link_libraries(Conic osqp osqp::osqp)
-else()
-  casadi_plugin_link_libraries(Conic osqp osqp)
-endif()
+casadi_plugin_link_libraries(Conic osqp osqp::osqp)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 set_target_properties(casadi_conic_osqp PROPERTIES COMPILE_FLAGS "-Wno-unused-variable -Wno-unknown-warning-option")


### PR DESCRIPTION
First of all, thanks a lot for the new 3.6.0 release, it is full of interesting features!

I tried to compile casadi with WITH_OSQP=ON and WITH_BUILD_OSQP=OFF, and the build was failing with error:
~~~
C:\src\casadi\casadi\interfaces\ipopt\ipopt_nlp.hpp(55): note: see declaration of 'casadi::IpoptUserClass'
[63/162] Building CXX object casadi\interfaces\osqp\CMakeFiles\casadi_conic_osqp.dir\osqp_interface.cpp.obj
FAILED: casadi/interfaces/osqp/CMakeFiles/casadi_conic_osqp.dir/osqp_interface.cpp.obj
C:\PROGRA~2\MIB055~1\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe  /nologo /TP -DCASADI_VERSION=31 -DHAVE_SIMPLE_MKSTEMPS -DUSE_CXX11 -DWITH_DEEPBIND -DWITH_DEPRECATED_FEATURES -DWITH_DL -DWITH_FMU -D_SCL_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES -Dcasadi_conic_osqp_EXPORTS -IC:\src\casadi\. -IC:\src\casadi\build -IC:\src\casadi\casadi\interfaces\osqp\.. -IC:\src\casadi\build\casadi\core\runtime -IC:\src\casadi\casadi\core\..\.. -IC:\src\casadi\build\casadi\core\..\.. /DWIN32 /D_WINDOWS /W3 /GR /EHsc  /MDd /Zi /Ob0 /Od /RTC1 /showIncludes /Focasadi\interfaces\osqp\CMakeFiles\casadi_conic_osqp.dir\osqp_interface.cpp.obj /Fdcasadi\interfaces\osqp\CMakeFiles\casadi_conic_osqp.dir\ /FS -c C:\src\casadi\casadi\interfaces\osqp\osqp_interface.cpp
C:\src\casadi\casadi\interfaces\osqp\osqp_interface.hpp(34): fatal error C1083: Cannot open include file: 'osqp.h': No such file or directory
~~~

The issue is that `find_package(OSQP)` creates an imported target `osqp::osqp` , but then in the code we actually link to `osqp`, see https://github.com/casadi/casadi/blob/3.6.0/casadi/interfaces/osqp/CMakeLists.txt . To fix this, I added an if to link to `osqp::osqp` if `WITH_BUILD_OSQP` is `OFF`. 

In the same modification, I also removed the option `USE_SYSTEM_WISE_OSQP` that was added in https://github.com/casadi/casadi/pull/2671 and release in 3.6.0, as it is redudant considering that we already have `WITH_BUILD_OSQP=OFF`. Anyhow, if you prefer I can add back support for this option, for backward compatibility with release 3.6.0 .

Note that an alternative option is to name the targed created in https://github.com/casadi/casadi/blob/b88a5d63583114bc2abbc29857895fc146b503b3/CMakeLists.txt#L1484 `osqp::osqp` instead of `osqp`, so that in the rest of the code we can just refer to `osqp::osqp`, indipendently of how it was created, via `add_library` or indirectly via `find_package`.