### PR TITLE
Fix compilation of WITH_TINYXML=ON and WITH_BUILD_TINYXML=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,11 +597,7 @@ set(BUILD_PROXQP_DEPENDENCIES EIGEN3 SIMDE)
 option(WITH_BUILD_TINYXML "Compile the included TinyXML source code" ON)
 option(WITH_TINYXML "Compile the interface to TinyXML" ON)
 if(WITH_TINYXML)
-  if(WITH_BUILD_TINYXML)
-    # build the included tinyxml
-    set(TINYXML_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/external_packages/tinyxml-2.6.2)
-    set(TINYXML_LIBRARIES casadi_tinyxml)
-  else()
+  if(NOT WITH_BUILD_TINYXML)
     # try to find system tinyxml
     find_package(TINYXML REQUIRED)
   endif()

--- a/casadi/interfaces/tinyxml/CMakeLists.txt
+++ b/casadi/interfaces/tinyxml/CMakeLists.txt
@@ -4,8 +4,10 @@ casadi_plugin(XmlFile tinyxml
   tinyxml_interface.hpp
   tinyxml_interface.cpp
   tinyxml_interface_meta.cpp)
-casadi_plugin_link_libraries(XmlFile tinyxml tinyxml2)
+casadi_plugin_link_libraries(XmlFile tinyxml tinyxml2::tinyxml2)
 
-install(TARGETS tinyxml2
-RUNTIME DESTINATION ${LIB_PREFIX}
-LIBRARY DESTINATION ${LIB_PREFIX})
+if(WITH_BUILD_TINYXML)
+  install(TARGETS tinyxml2
+  RUNTIME DESTINATION ${LIB_PREFIX}
+  LIBRARY DESTINATION ${LIB_PREFIX})
+endif()

--- a/cmake/FindTINYXML.cmake
+++ b/cmake/FindTINYXML.cmake
@@ -1,17 +1,22 @@
-# Get package info using pkg-config
-find_package(PkgConfig)
-pkg_search_module(TINYXML tinyxml)
+# Search for tinyxml2 via find_package(tinyxml2)
+include(CMakeFindDependencyMacro)
+find_dependency(tinyxml2 NO_MODULE)
 
-include(canonicalize_paths)
-canonicalize_paths(TINYXML_LIBRARY_DIRS)
-
-if(NOT TINYXML_INCLUDE_DIR)
-find_path(TINYXML_INCLUDE_DIR
-    tinyxml.h
-#  HINTS $ENV{SUNDIALS}/include
-  )
+# If this does not work, search for tinyxml2 via pkg-config
+if(NOT tinyxml2_FOUND OR NOT TARGET tinyxml2::tinyxml2)
+  find_package(PkgConfig QUIET)
+  if(PkgConfig_FOUND)
+    pkg_check_modules(tinyxml2 QUIET IMPORTED_TARGET tinyxml2)
+    if(TARGET PkgConfig::tinyxml2 AND NOT TARGET tinyxml2::tinyxml2)
+      # Define tinyxml2::tinyxml2 so in the code we just use tinyxml2::tinyxml2
+      # as if the package was found via find_package(tinyxml2)
+      add_library(tinyxml2::tinyxml2 INTERFACE IMPORTED)
+      # Equivalent to target_link_libraries INTERFACE, but compatible with CMake 3.10
+      set_target_properties(tinyxml2::tinyxml2 PROPERTIES INTERFACE_LINK_LIBRARIES PkgConfig::tinyxml2)
+      set(tinyxml2_FOUND TRUE)
+    endif()
+  endif()
 endif()
 
-# Set standard flags
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(TINYXML DEFAULT_MSG TINYXML_LIBRARIES TINYXML_INCLUDE_DIR)
+find_package_handle_standard_args(TINYXML DEFAULT_MSG tinyxml2_FOUND)

--- a/cmake/FindTINYXML.cmake
+++ b/cmake/FindTINYXML.cmake
@@ -1,6 +1,5 @@
 # Search for tinyxml2 via find_package(tinyxml2)
-include(CMakeFindDependencyMacro)
-find_dependency(tinyxml2 NO_MODULE)
+find_package(tinyxml2 QUIET NO_MODULE)
 
 # If this does not work, search for tinyxml2 via pkg-config
 if(NOT tinyxml2_FOUND OR NOT TARGET tinyxml2::tinyxml2)


### PR DESCRIPTION
Similar to https://github.com/casadi/casadi/pull/3077, but with `TINYXML`/`tinyxml2` . 

Most modern distribution ship `tinyxml2` with a CMake config file so we can just do `find_package(tinyxml2)`, but some of them do not ship it, so I also added a fallback to use pkg-config.