### PR TITLE
Fix compilation of WITH_PROXQP=ON and WITH_BUILD_PROXQP=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1461,6 +1461,9 @@ if(WITH_PROXQP)
         CMAKE_ARGS --debug-find -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH -DSimde_DIR=${CMAKE_BINARY_DIR}/external_projects/share/eigen3/cmake -DEigen3_DIR=${CMAKE_BINARY_DIR}/external_projects/share/eigen3/cmake -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/external_projects/include/ -DCMAKE_INCLUDE_PATH=${CMAKE_BINARY_DIR}/external_projects/include/ -DBUILD_TESTING=OFF -DBUILD_PYTHON_INTERFACE=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>)
         # --debug-find
     add_library(proxqp INTERFACE)
+    # This is similar to ALIAS but works fine on imported targets with CMake 3.10
+    add_library(proxsuite::proxsuite INTERFACE IMPORTED)
+    set_target_properties(proxsuite::proxsuite PROPERTIES INTERFACE_LINK_LIBRARIES proxqp)
     add_dependencies(proxqp proxqp-external)
     target_include_directories(proxqp INTERFACE "${CMAKE_BINARY_DIR}/external_projects/include")
     target_link_libraries(proxqp INTERFACE eigen3)

--- a/casadi/interfaces/proxqp/CMakeLists.txt
+++ b/casadi/interfaces/proxqp/CMakeLists.txt
@@ -8,7 +8,7 @@ casadi_plugin(Conic proxqp
   proxqp_interface_meta.cpp)
 
 
-casadi_plugin_link_libraries(Conic proxqp proxqp)
+casadi_plugin_link_libraries(Conic proxqp proxsuite::proxsuite)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set_target_properties(casadi_conic_proxqp PROPERTIES COMPILE_FLAGS "-Wno-unused-variable -Wno-unknown-warning-option -Wno-type-limits")

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -53,6 +53,10 @@ macro(_eigen3_check_version)
   endif(NOT EIGEN3_VERSION_OK)
 endmacro(_eigen3_check_version)
 
+# If Eigen3Config.cmake is installed, this defines
+# EIGEN3_INCLUDE_DIR
+find_package(Eigen3 NO_MODULE QUIET)
+
 if(EIGEN3_INCLUDE_DIR)
 
   # in cache already

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -15,6 +15,14 @@
 # Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
 # Redistribution and use is allowed according to the terms of the 2-clause BSD license.
 
+# If Eigen3Config.cmake is installed, this defines
+# EIGEN3_INCLUDE_DIR
+# It is important that this is called before Eigen3_FIND_VERSION_***
+# variables are defined as in some CMake version this variables
+# interfere with the correct finding of Eigen3 module, complaining
+# that the found version is not compatible with 2.91.0
+find_package(Eigen3 NO_MODULE QUIET)
+
 if(NOT Eigen3_FIND_VERSION)
   if(NOT Eigen3_FIND_VERSION_MAJOR)
     set(Eigen3_FIND_VERSION_MAJOR 2)
@@ -52,10 +60,6 @@ macro(_eigen3_check_version)
                    "but at least version ${Eigen3_FIND_VERSION} is required")
   endif(NOT EIGEN3_VERSION_OK)
 endmacro(_eigen3_check_version)
-
-# If Eigen3Config.cmake is installed, this defines
-# EIGEN3_INCLUDE_DIR
-find_package(Eigen3 NO_MODULE QUIET)
 
 if(EIGEN3_INCLUDE_DIR)
 

--- a/cmake/FindPROXQP.cmake
+++ b/cmake/FindPROXQP.cmake
@@ -1,0 +1,6 @@
+# Search for proxsuite via find_package(tinyxml2)
+include(CMakeFindDependencyMacro)
+find_dependency(proxsuite NO_MODULE)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PROXQP DEFAULT_MSG proxsuite_FOUND)


### PR DESCRIPTION
To achieve this, I added the `FindPROXQP.cmake` file to ensure that the `find_package(PROXQP)` call resulted in a success, and fixed a bug in the `FindEigen3.cmake` that ignored the `Eigen3Config.cmake` file even if it was available in the system.