### PR TITLE
Restore compatibility with Ipopt < 3.14.0

### DIFF
--- a/casadi/interfaces/ipopt/ipopt_interface.cpp
+++ b/casadi/interfaces/ipopt/ipopt_interface.cpp
@@ -409,8 +409,10 @@ namespace casadi {
       return "Maximum_CpuTime_Exceeded";
     case Feasible_Point_Found:
       return "Feasible_Point_Found";
+#if (IPOPT_VERSION_MAJOR > 3) || (IPOPT_VERSION_MAJOR == 3 && IPOPT_VERSION_MAJOR >= 14)
     case Maximum_WallTime_Exceeded:
       return "Maximum_WallTime_Exceeded";
+#endif
     }
     return "Unknown";
   }
@@ -445,8 +447,11 @@ namespace casadi {
     m->success = status==Solve_Succeeded || status==Solved_To_Acceptable_Level
                  || status==Feasible_Point_Found;
     if (status==Maximum_Iterations_Exceeded ||
-        status==Maximum_WallTime_Exceeded ||
         status==Maximum_CpuTime_Exceeded) m->unified_return_status = SOLVER_RET_LIMITED;
+
+#if (IPOPT_VERSION_MAJOR > 3) || (IPOPT_VERSION_MAJOR == 3 && IPOPT_VERSION_MAJOR >= 14)
+    if (status==Maximum_WallTime_Exceeded) m->unified_return_status = SOLVER_RET_LIMITED;
+#endif
 
     // Save results to outputs
     casadi_copy(m->gk, ng_, d_nlp->z + nx_);

--- a/casadi/interfaces/ipopt/ipopt_nlp.cpp
+++ b/casadi/interfaces/ipopt/ipopt_nlp.cpp
@@ -236,7 +236,11 @@ namespace casadi {
       g_[c_pos[i]] += tnlp_adapter->c_rhs_[i];
     }
 
+#if (IPOPT_VERSION_MAJOR > 3) || (IPOPT_VERSION_MAJOR == 3 && IPOPT_VERSION_MAJOR >= 14)
     tnlp_adapter->ResortBounds(z_L, z_L_, z_U, z_U_);
+#else
+    tnlp_adapter->ResortBnds(z_L, z_L_, z_U, z_U_);
+#endif
     // Copied from Ipopt source: Hopefully the following is correct to recover the bound
     // multipliers for fixed variables (sign ok?)
     if (tnlp_adapter->fixed_variable_treatment_==TNLPAdapter::MAKE_CONSTRAINT &&


### PR DESCRIPTION
In some of our builds, we need to build CasADi with Ipopt older then 3.14.0 . The necessary modifications to be compatible with both Ipopt < 3.14.0 and Ipopt >= 3.14.0 are quite minimal, see the modifications propsed in the PR.

I am not sure if you are interested in this patch, so feel free to close the PR if you are not interested.