### PR TITLE
Updated cvx work vectors

### DIFF
--- a/casadi/core/convexify.cpp
+++ b/casadi/core/convexify.cpp
@@ -271,7 +271,13 @@ namespace casadi {
 
     d.sz_w = 0;
     if (d.config.strategy==CVX_EIGEN_REFLECT || d.config.strategy==CVX_EIGEN_CLIP) {
-      d.sz_w = std::max(block_size, 2*(block_size-1)*d.config.max_iter_eig);
+      // Work vector size needed for Givens rotations (c and s)
+      casadi_int sz_w_givens = 2*(block_size-1)*d.config.max_iter_eig;
+      // Work vector size needed for house holder transformations (beta and p)
+      casadi_int sz_w_house = block_size-2 + block_size;
+      // Work vector size needed for casadi_cvx
+      d.sz_w = sz_w_givens + sz_w_house;
+      // Additional work vectors
       if (d.config.Hsp_project) d.sz_w = std::max(d.sz_w, Hsp.size1());
       if (d.config.scc_transform) d.sz_w += block_size*block_size;
       if (inplace) d.sz_w = std::max(d.sz_w, Hsp.size1()+d.Hrsp.nnz());


### PR DESCRIPTION
Closes #3169 

Changes local variable arrays in casadi_cvx to work vectors supplied to the function call. Avoids buffer overflow if the required array is too large.

This pull requests appears to break backward compatibility to load code generated with casadi 3.5.5 I assume this is because the work vectors in the code generated with casadi 3.5.5 is not of suitable size for the changes to casadi_cvx.

It also includes a test that still fails, code generation with main when calling convexify on a large strongly connected matrix (stack overflow?).