### PR TITLE
Fixed logsumexp for SX

### DIFF
--- a/casadi/core/matrix_impl.hpp
+++ b/casadi/core/matrix_impl.hpp
@@ -1217,7 +1217,7 @@ namespace casadi {
   Matrix<Scalar> Matrix<Scalar>::
   _logsumexp(const Matrix<Scalar>& x) {
     Matrix<Scalar> mx = mmax(x);
-    return log(sum1(exp(x-mx)));
+    return mx+log(sum1(exp(x-mx)));
   }
 
   template<typename Scalar>

--- a/test/python/sx.py
+++ b/test/python/sx.py
@@ -1519,7 +1519,7 @@ class SXtests(casadiTestCase):
       self.assertEqual(res.shape[1],4)
 
   def test_logsumexp(self):
-    x = MX.sym("x",3)
+    x = SX.sym("x",3)
 
     f_ref = Function("f_ref",[x],[log(exp(x[0])+exp(x[1])+exp(x[2]))])
     f = Function("f",[x],[logsumexp(x)])


### PR DESCRIPTION
Fixes issue #3208 and replaces `MX` with `SX` in the `sx.py` test file so that logsumexp actually gets tested for `SX` (which I assume is what was intended, as the file is for testing `SX` not `MX`, for which logsumexp works as expected).