### PR TITLE
Return empty string instead of nullptr

### DIFF
--- a/casadi/core/calculus.hpp
+++ b/casadi/core/calculus.hpp
@@ -1688,7 +1688,7 @@ case OP_HYPOT:     DerBinaryOperation<OP_HYPOT>::derf(X, Y, F, D);      break;
     case OP_HYPOT:          return "hypot";
     case OP_LOGSUMEXP:      return "logsumexp";
     }
-    return nullptr;
+    return std::string{};
   }
 
   template<typename T>


### PR DESCRIPTION
C++23 makes construction of a std::string from nullptr ill-formed (see https://wg21.link/P2166R1). Return an empty string instead.