### PR TITLE
Don't construct nullptr string in calculus.hpp

### DIFF
--- a/casadi/core/calculus.hpp
+++ b/casadi/core/calculus.hpp
@@ -1688,7 +1688,7 @@ case OP_HYPOT:     DerBinaryOperation<OP_HYPOT>::derf(X, Y, F, D);      break;
     case OP_HYPOT:          return "hypot";
     case OP_LOGSUMEXP:      return "logsumexp";
     }
-    return nullptr;
+    return "<invalid-op>";
   }
 
   template<typename T>


### PR DESCRIPTION
Constructing a `std::string` with `nullptr` is not allowed (compiler error in C++23, and throws an exception in earlier versions): https://en.cppreference.com/w/cpp/string/basic_string/basic_string