### PR TITLE
Add change options to ipopt

### DIFF
--- a/casadi/core/function.cpp
+++ b/casadi/core/function.cpp
@@ -1115,11 +1115,9 @@ namespace casadi {
 
   void Function::change_option(const std::string& option_name, const GenericType& option_value) {
     try {
-      // Assert existance
-      if (!has_option(option_name))
-        casadi_error("Option '" + option_name + "' does not exist");
       // Call internal class
-      (*this)->change_option(option_name, option_value);
+      scoped_checkout<Function> mem(*this);
+      (*this)->change_option(memory(mem), option_name, option_value);
     } catch(std::exception& e) {
       THROW_ERROR("change_option", e.what());
     }

--- a/casadi/core/function_internal.cpp
+++ b/casadi/core/function_internal.cpp
@@ -438,6 +438,11 @@ namespace casadi {
     }
   }
 
+  void FunctionInternal::change_option(void* mem, const std::string& option_name,
+                                     const GenericType& option_value) {
+    change_option(option_name, option_value);
+  }
+
   void FunctionInternal::init(const Dict& opts) {
     // Call the initialization method of the base class
     ProtoFunction::init(opts);
@@ -912,6 +917,11 @@ namespace casadi {
       // Failure
       casadi_error("Option '" + option_name + "' cannot be changed");
     }
+  }
+
+  void ProtoFunction::change_option(void* mem, const std::string& option_name,
+                                  const GenericType& option_value) {
+   change_option(option_name, option_value);
   }
 
   std::vector<std::string> FunctionInternal::get_free() const {

--- a/casadi/core/function_internal.hpp
+++ b/casadi/core/function_internal.hpp
@@ -134,10 +134,19 @@ namespace casadi {
         \identifier{jj} */
     bool has_option(const std::string &option_name) const;
 
-    /** \brief Change option after object creation for debugging
+    /** \brief Change option after object creation
 
         \identifier{jk} */
     virtual void change_option(const std::string& option_name, const GenericType& option_value);
+
+    /** \brief Change options after object creation 
+
+        Internally changes the options of this function.
+
+        \identifier{jk} */
+    virtual void change_option(void* mem,
+                               const std::string& option_name,
+                               const GenericType& option_value);
 
     /** \brief Initialize
 
@@ -305,8 +314,9 @@ namespace casadi {
     /** \brief Change option after object creation for debugging
 
         \identifier{k5} */
-    void change_option(const std::string& option_name, const GenericType& option_value) override;
-
+    virtual void change_option(const std::string& option_name, const GenericType& option_value) override;
+    virtual void change_option(void* mem, const std::string& option_name,
+                       const GenericType& option_value) override;
     /** \brief Initialize
 
         \identifier{k6} */

--- a/casadi/core/nlpsol.cpp
+++ b/casadi/core/nlpsol.cpp
@@ -1183,6 +1183,12 @@ namespace casadi {
     return Function(name, arg, res, inames, onames, options);
   }
 
+  void Nlpsol::change_option(void* mem,
+                             const std::string& option_name,
+                             const GenericType& option_value) {
+    OracleFunction::change_option(mem, option_name, option_value);
+  }
+
   int Nlpsol::callback(NlpsolMemory* m) const {
     // Quick return if no callback function
     if (fcallback_.is_null()) return 0;

--- a/casadi/core/nlpsol_impl.hpp
+++ b/casadi/core/nlpsol_impl.hpp
@@ -247,6 +247,10 @@ namespace casadi {
                          const Dict& opts) const override;
     ///@}
 
+    // Change option after object creation
+    void change_option(void* mem, const std::string& option_name,
+                       const GenericType& option_value) override;
+
     // Call the callback function
     int callback(NlpsolMemory* m) const;
 

--- a/casadi/core/oracle_function.cpp
+++ b/casadi/core/oracle_function.cpp
@@ -431,6 +431,12 @@ Dict OracleFunction::get_stats(void *mem) const {
   return stats;
 }
 
+void OracleFunction::change_option(void* mem,
+                                   const std::string& option_name,
+                                   const GenericType& option_value) {
+  FunctionInternal::change_option(option_name, option_value);
+}
+
 int OracleFunction::local_init_mem(void* mem) const {
   if (ProtoFunction::init_mem(mem)) return 1;
   if (!mem) return 1;

--- a/casadi/core/oracle_function.hpp
+++ b/casadi/core/oracle_function.hpp
@@ -230,6 +230,9 @@ namespace casadi {
     /// Get all statistics
     Dict get_stats(void* mem) const override;
 
+    virtual void change_option(void* mem, const std::string& option_name,
+                               const GenericType& option_value) override;
+
     /** \brief Serialize an object without type information
 
         \identifier{r} */

--- a/casadi/interfaces/ipopt/ipopt_interface.hpp
+++ b/casadi/interfaces/ipopt/ipopt_interface.hpp
@@ -158,6 +158,8 @@ namespace casadi {
     /// All IPOPT options
     Dict opts_;
 
+    void change_option(void* mem, const std::string& option_name, const GenericType& option_value) override;
+
     // Ipopt callback functions
     void finalize_solution(IpoptMemory* m, const double* x, const double* z_L, const double* z_U,
                            const double* g, const double* lambda, double obj_value,


### PR DESCRIPTION
The idea is that after constructing an NLP-solver object, you sometimes want to resolve with different options to make your solution more accurate. It would also solve the request from:
https://groups.google.com/g/casadi-users/c/2HWvSFdx1Gs?pli=1

If this is approved, I will first add some tests before merging.