### PR TITLE
fix: use size_t instead of casadi_int in loop for hash combine

### DIFF
--- a/casadi/core/sparsity.hpp
+++ b/casadi/core/sparsity.hpp
@@ -1200,7 +1200,7 @@ namespace casadi {
 
       \identifier{dq} */
   inline void hash_combine(std::size_t& seed, const casadi_int* v, std::size_t sz) {
-    for (casadi_int i=0; i<sz; ++i) hash_combine(seed, v[i]);
+    for (std::size_t i=0; i<sz; ++i) hash_combine(seed, v[i]);
   }
 
   /** \brief Generate a hash value incrementally (function taken from boost)


### PR DESCRIPTION
Fix sign of type in looping of array. Compiled with -Werror will raise a W-sing=comparison error