### PR TITLE
fix: use Fmu2::deserialize only if compiled with WITH_FMI2

### DIFF
--- a/casadi/core/fmu.cpp
+++ b/casadi/core/fmu.cpp
@@ -668,11 +668,12 @@ FmuInternal::FmuInternal(DeserializingStream& s) {
 FmuInternal* FmuInternal::deserialize(DeserializingStream& s) {
   std::string class_name;
   s.unpack("FmuInternal::type", class_name);
+  #ifdef WITH_FMI2
   if (class_name=="Fmu2") {
     return Fmu2::deserialize(s);
-  } else {
-    casadi_error("Cannot deserialize type '" + class_name + "'");
   }
+  #endif
+  casadi_error("Cannot deserialize type '" + class_name + "'");
 }
 
 } // namespace casadi


### PR DESCRIPTION
Use `Fmu2::deserialize` only if compiled with `WITH_FMI2` in `fmu.cpp`. If not compiled `WITH_FMI2` compiler complains because deserialize has neither been declared nor implemented.