### PR TITLE
Fix build for WITH_FMI2=OFF

### DIFF
--- a/casadi/core/fmu.cpp
+++ b/casadi/core/fmu.cpp
@@ -669,7 +669,11 @@ FmuInternal* FmuInternal::deserialize(DeserializingStream& s) {
   std::string class_name;
   s.unpack("FmuInternal::type", class_name);
   if (class_name=="Fmu2") {
+#ifdef WITH_FMI2
     return Fmu2::deserialize(s);
+#else
+    casadi_error("Cannot deserialize type '" + class_name + "'");
+#endif
   } else {
     casadi_error("Cannot deserialize type '" + class_name + "'");
   }


### PR DESCRIPTION
With this change, the casadi build for `WITH_FMI2=OFF` works. I wanted to change as little as possible, but note that there exists no path for which this function does not throw an error in case `WITH_FMI2=OFF`, hence further simplification is possible.