### PR TITLE
Add error message when factorization in IDAS fails

### DIFF
--- a/casadi/interfaces/sundials/idas_interface.cpp
+++ b/casadi/interfaces/sundials/idas_interface.cpp
@@ -857,7 +857,10 @@ int IdasInterface::psetupF(double t, N_Vector xz, N_Vector xzdot, N_Vector rr,
     }
 
     // Factorize the linear system
-    if (s.linsolF_.nfact(m->jacF, m->mem_linsolF)) return 1;
+    if (s.linsolF_.nfact(m->jacF, m->mem_linsolF)) {
+      uerr() << "Failed to factorize shifted Jacobian (system may be singular)" << std::endl;
+      return 1;
+    }
     m->cj_last = cj;
 
     return 0;


### PR DESCRIPTION
It cost me a while to troubleshoot a problem occurring during the factorization in IDAS. I think that  an error message produced when factorizations cannot be computed could be beneficial to future users in this regard.