### PR TITLE
Add warning when Newton method fails to converge

### DIFF
--- a/casadi/solvers/newton.cpp
+++ b/casadi/solvers/newton.cpp
@@ -234,7 +234,11 @@ namespace casadi {
     casadi_copy(m->x, n_, m->ires[iout_]);
 
     // Store the iteration count
-    if (success) m->return_status = "success";
+    if (success) {
+      m->return_status = "success";
+    } else {
+      casadi_warning("Newton method failed to converge, provided solution may be inaccurate");
+    }
     if (verbose_) casadi_message("Newton algorithm took " + str(m->iter) + " steps");
 
     m->success = success;


### PR DESCRIPTION
Apparently the Newton-based rootfinder does not give any indication to the user when the method does not converge and silently returns a (possibly very inaccurate) solution corresponding to some iterate.

I think it would be a good idea to instead issue a warning message so users are aware that there is a possible problem with the value return from the function.