### PR TITLE
codegeneration: Add optional dest. path argument

### DIFF
--- a/casadi/core/function.cpp
+++ b/casadi/core/function.cpp
@@ -1168,7 +1168,8 @@ namespace casadi {
     return generate(fname, "", opts);
   }
 
-  std::string Function::generate(const std::string& fname, const std::string& path, const Dict& opts) const {
+  std::string Function::generate(const std::string& fname, const std::string& path,
+                                 const Dict& opts) const {
     CodeGenerator gen(fname, opts);
     gen.add(*this);
     return gen.generate(path);

--- a/casadi/core/function.cpp
+++ b/casadi/core/function.cpp
@@ -1165,9 +1165,13 @@ namespace casadi {
   }
 
   std::string Function::generate(const std::string& fname, const Dict& opts) const {
+    return generate(fname, "", opts);
+  }
+
+  std::string Function::generate(const std::string& fname, const std::string& path, const Dict& opts) const {
     CodeGenerator gen(fname, opts);
     gen.add(*this);
-    return gen.generate();
+    return gen.generate(path);
   }
 
   std::string Function::generate_dependencies(const std::string& fname, const Dict& opts) const {

--- a/casadi/core/function.hpp
+++ b/casadi/core/function.hpp
@@ -837,7 +837,8 @@ namespace casadi {
     /** \brief Export / Generate C code for the function
 
         \identifier{1wv} */
-    std::string generate(const std::string& fname, const std::string& path, const Dict& opts=Dict()) const;
+    std::string generate(const std::string& fname, const std::string& path,
+                         const Dict& opts=Dict()) const;
 
     /** \brief Export / Generate C code for the function
 

--- a/casadi/core/function.hpp
+++ b/casadi/core/function.hpp
@@ -837,6 +837,11 @@ namespace casadi {
     /** \brief Export / Generate C code for the function
 
         \identifier{1wv} */
+    std::string generate(const std::string& fname, const std::string& path, const Dict& opts=Dict()) const;
+
+    /** \brief Export / Generate C code for the function
+
+        \identifier{1wv} */
     std::string generate(const Dict& opts=Dict()) const;
 
     /** \brief Export / Generate C code for the dependency function

--- a/swig/internal.i
+++ b/swig/internal.i
@@ -1330,6 +1330,9 @@
 %exception  casadi::Function::generate(const std::string &fname, const Dict &opts=Dict()) const {
  CATCH_OR_NOT(INTERNAL_MSG() $action) 
 }
+%exception  casadi::Function::generate(const std::string &fname, const std::string &path, const Dict &opts=Dict()) const {
+ CATCH_OR_NOT(INTERNAL_MSG() $action) 
+}
 %exception  casadi::Function::generate_dependencies(const std::string &fname, const Dict &opts=Dict()) const {
  CATCH_OR_NOT(INTERNAL_MSG() $action) 
 }


### PR DESCRIPTION
Add argument for code-generation outputs destination folder as mentioned in #3741.
I am not sure `prefix` in [gen.generate(..)](https://github.com/casadi/casadi/blob/72764dc73eab7b935db7e302278508855815883b/casadi/core/code_generator.cpp#L450) was actually supposed to be a path and not just a simple filename prefix.
In the latter case this should expanded to better support paths.

Would enable i.e. the following:
```python
from casadi import MX, Function, sin
from pathlib import Path
p = Path("./generated").mkdir(exist_ok=True)

x = MX.sym('x',2)
y = MX.sym('y')
f = Function('f',[x,y],[x,sin(y)*x],['x','y'],['r','q'])

f.generate('gen0.c')
print(open('gen0.c','r').read())

f.generate('gen1.c', 'generated/')
print(open(Path('generated') / 'gen1.c','r').read())

f.generate('gen2.c', {'prefix': 'test2'} )
print(open('gen2.c','r').read())

f.generate('gen3.c', 'generated/', {'prefix': 'test3'} )
print(open(Path('generated') / 'gen3.c','r').read())

```

What can also be done:
- Make it a consistent signature also for `generate_dependencies` or similar methods
- Make it  path friendly i.e. automatically add trailing slash, check portability