### PR TITLE
Build aarch64 py312 in CI

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -260,7 +260,7 @@ jobs:
               - type: append
                 matrix:
                   arch: [manylinux2014-aarch64]
-                  py2: ["36","37","38","39","310","311"]
+                  py2: ["36","37","38","39","310","311","312"]
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
   


### PR DESCRIPTION
This PR adds `aarch64-py312` build which is currently missing from CI.

Unfortunately, this does not build upfront, because `ghcr.io/jgillis/manylinux2014-aarch64:production` is not the latest and it's missing `/opt/python/cp312` so the build fails.

It just needs `dockcross/manylinux2014-aarch64:latest` to be pushed to `ghcr.io/jgillis/manylinux2014-aarch64:production` first.

The new image has `/opt/python/cp312` - tested it here: https://github.com/andiradulescu/casadi/actions/runs/9888443900/job/27313156267