### PR TITLE
Fix PYTHON_INCLUDE_DIR path

### DIFF
--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -6,6 +6,7 @@ import subprocess
 import pathlib
 import multiprocessing
 from io import open
+import sysconfig
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
@@ -47,7 +48,7 @@ class CMakeBuild(build_ext):
             '-DSWIG_IMPORT=ON',
             '-DWITH_PYTHON=ON',
             '-DWITH_EXAMPLES=OFF',
-            '-DPYTHON_INCLUDE_DIR=' + self.include_dirs[0],
+            '-DPYTHON_INCLUDE_DIR=' + sysconfig.get_path('include'),
             '-DCMAKE_INSTALL_PREFIX=' + extdir,
             '-DWITH_SELFCONTAINED=ON',
             '-DWITH_DEEPBIND=ON'


### PR DESCRIPTION
CasADi building with Python 3.12 on aarch64 with [uv](https://github.com/astral-sh/uv) (because it misses the [prebuilt whl](https://github.com/casadi/casadi/pull/3756)) fails.

This change fixes the issue, changing `PYTHON_INCLUDE_DIR` to use `sysconfig.get_path("include")` instead.

More details about the uv issue [here](https://github.com/astral-sh/uv/issues/5004).

Issue seems to happen also in [pyodide](https://github.com/pyodide/pyodide/issues/4551).