### PR TITLE
qpOASES: parameter enableDriftCorrection was wrongly mapped

### DIFF
--- a/casadi/core/fmu2.cpp
+++ b/casadi/core/fmu2.cpp
@@ -964,14 +964,14 @@ void Fmu2::serialize_body(SerializingStream &s) const {
   s.pack("Fmu2::init_boolean", init_boolean_);
   s.pack("Fmu2::init_string", init_string_);
 
-  s.pack("Fmu2::vn_aux_real_", vn_aux_real_);
-  s.pack("Fmu2::vn_aux_integer_", vn_aux_integer_);
-  s.pack("Fmu2::vn_aux_boolean_", vn_aux_boolean_);
-  s.pack("Fmu2::vn_aux_string_", vn_aux_string_);
-  s.pack("Fmu2::vr_aux_real_", vr_aux_real_);
-  s.pack("Fmu2::vr_aux_integer_", vr_aux_integer_);
-  s.pack("Fmu2::vr_aux_boolean_", vr_aux_boolean_);
-  s.pack("Fmu2::vr_aux_string_", vr_aux_string_);
+  s.pack("Fmu2::vn_aux_real", vn_aux_real_);
+  s.pack("Fmu2::vn_aux_integer", vn_aux_integer_);
+  s.pack("Fmu2::vn_aux_boolean", vn_aux_boolean_);
+  s.pack("Fmu2::vn_aux_string", vn_aux_string_);
+  s.pack("Fmu2::vr_aux_real", vr_aux_real_);
+  s.pack("Fmu2::vr_aux_integer", vr_aux_integer_);
+  s.pack("Fmu2::vr_aux_boolean", vr_aux_boolean_);
+  s.pack("Fmu2::vr_aux_string", vr_aux_string_);
 
   s.pack("Fmu2::declared_ad", declared_ad_);
 }

--- a/casadi/core/getnonzeros.cpp
+++ b/casadi/core/getnonzeros.cpp
@@ -627,8 +627,8 @@ namespace casadi {
   }
 
   GetNonzerosSlice2::GetNonzerosSlice2(DeserializingStream& s) : GetNonzeros(s) {
-    s.unpack("GetNonzerosVector2::inner", inner_);
-    s.unpack("GetNonzerosVector2::outer", outer_);
+    s.unpack("GetNonzerosSlice2::inner", inner_);
+    s.unpack("GetNonzerosSlice2::outer", outer_);
   }
 
   MXNode* GetNonzeros::deserialize(DeserializingStream& s) {

--- a/casadi/interfaces/qpoases/qpoases_interface.cpp
+++ b/casadi/interfaces/qpoases/qpoases_interface.cpp
@@ -248,7 +248,7 @@ namespace casadi {
       } else if (op.first=="enableNZCTests") {
         ops_.enableNZCTests = to_BooleanType(op.second);
       } else if (op.first=="enableDriftCorrection") {
-        ops_.enableRegularisation = to_BooleanType(op.second);
+        ops_.enableDriftCorrection = to_BooleanType(op.second);
       } else if (op.first=="enableCholeskyRefactorisation") {
         ops_.enableCholeskyRefactorisation = op.second;
       } else if (op.first=="enableEqualities") {


### PR DESCRIPTION
This bugfix is to prevent the parameter "enableDriftCorrection" to wrongly set the member enableRegularisation. The member enableRegularisation is set by a separate string.