### PR TITLE
Allow compiling with Emscripten for a WASM target

### DIFF
--- a/casadi/core/casadi_os.cpp
+++ b/casadi/core/casadi_os.cpp
@@ -115,7 +115,7 @@ handle_t open_shared_library(const std::string& lib, const std::vector<std::stri
             flag = RTLD_LAZY | RTLD_LOCAL;
         }
     #ifdef WITH_DEEPBIND
-    #ifndef __APPLE__
+    #if !defined(__APPLE__) && !defined(__EMSCRIPTEN__)
         flag |= RTLD_DEEPBIND;
     #endif
     #endif

--- a/casadi/core/serializing_stream.cpp
+++ b/casadi/core/serializing_stream.cpp
@@ -155,7 +155,7 @@ namespace casadi {
       for (int j=0;j<4;++j) pack(c[j]);
     }
 
-#if SIZE_MAX != UINT_MAX
+#if SIZE_MAX != UINT_MAX || defined(__EMSCRIPTEN__)
     void DeserializingStream::unpack(unsigned int& e) {
       assert_decoration('u');
       uint32_t n;

--- a/casadi/core/serializing_stream.hpp
+++ b/casadi/core/serializing_stream.hpp
@@ -99,7 +99,7 @@ namespace casadi {
     void unpack(Slice& e);
     void unpack(int& e);
 
-#if SIZE_MAX != UINT_MAX
+#if SIZE_MAX != UINT_MAX || defined(__EMSCRIPTEN__)
     void unpack(unsigned int& e);
 #endif
     void unpack(bool& e);
@@ -236,7 +236,7 @@ namespace casadi {
     void pack(const GenericType& e);
     void pack(std::istream& s);
     void pack(int e);
-#if SIZE_MAX != UINT_MAX
+#if SIZE_MAX != UINT_MAX || defined(__EMSCRIPTEN__)
     void pack(unsigned int e);
 #endif
     void pack(bool e);


### PR DESCRIPTION
## Description

This PR enables compiling CasADi with the [Emscripten toolchain](https://emscripten.org/) for a [WebAssembly target](https://nachawati.me/blog/2023/08/08/compiling-casadi-webassembly/), where the bitness is currently 32 bits. Specifically, this disables the `RTLD_DEEPBIND` flag since I've found it to be more or less relevant for Linux systems (https://manpages.debian.org/bookworm/manpages-dev/dlopen.3.en.html#RTLD_DEEPBIND), allowing the serialising and deserialising unpacking in `DeserializingStream` to proceed by building upon bff1521e726cbb3a2eaa009f572f5d1c0ba17c84 (otherwise, the compiler complains about ambiguous function signatures).

This PR doesn't add a workflow for an [out-of-tree build](https://pyodide.org/en/stable/development/building-and-testing-packages.html) for [Pyodide](https://pyodide.org/) as of now – it just enables a successful compilation with the `emcc` and `em++` drop-in equivalents to the standard compiler frontends. However, if there is a positive response from the maintainers about this, I can look into doing that as well, either here or in a follow-up PR – it would help run the entire test suite for CasADi inside a special Pyodide virtual environment. It could lead to an added maintenance effort and subsequent burden, so if the extra effort is not ideal, I shall completely understand.

There was also a previous fix in https://github.com/casadi/casadi/pull/3759 to allow the Python interpreter's headers to be found in the correct directory, which has now been merged. It also fixed compilation outside of Pyodide, such as with the `uv` package manager and builds with `pip` that use [PEP 517](https://peps.python.org/pep-0517/) (it is nowadays enabled by default and can be disabled with `--no-pep517`).

P.S. These findings are coming from my PR to Pyodide, which aims to add CasADi in-tree to the list of packages, here: https://github.com/pyodide/pyodide/pull/4936, where I heartily invite the maintainers of CasADi to the discussion, and if you're interested, to become recipe maintainers for the in-tree build! It would help bring additional people to liaise and oversee any build failures that can arise from a bump in the Emscripten version (because it comes with an ABI break), or just to update and enhance the recipe in general where needed. The Emscripten version is tied to the Pyodide minor version, and Pyodide pushes forth new minor releases twice a year (with additional patch releases).


## Additional information

The optional interfaces to the rest of the solvers such as IPOPT, MUMPS, Gurobi, etc.) are not included in the Pyodide build right now since i. they would likely need special effort to compile all or even a few of them with Emscripten, ii. for size reasons, i.e., we want to reduce bandwidth usage in a web-based environment and therefore build a smaller wheel, iii. to be in line with the CasADi build procedure since they are currently disabled in the 32-bit builds in `binaries.yml`; and lastly, iv. to not strain CI time and keep it low for PRs in Pyodide, where all recipes are built in checks triggered on PRs.