### PR TITLE
Fix macOS binary compatibility by adding the `MACOSX_DEPLOYMENT_TARGET` environment variable

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -218,7 +218,7 @@ jobs:
           name: ${{github.job}}-${{ matrix.target}}
           path: ${{github.job}}-${{matrix.target}}.zip
           retention-days: 5
-          
+
   matrix-arch-py2:
     runs-on: ubuntu-20.04
     steps:
@@ -244,7 +244,7 @@ jobs:
                   py2: ["36","37","38","39","310","311","312"]
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
-  
+
   matrix-arch-py2-mac:
     runs-on: ubuntu-20.04
     steps:
@@ -263,7 +263,7 @@ jobs:
 
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
-           
+
   python-osx:
     needs: [core-osx,matrix-arch-py2-mac,swig,version]
     runs-on: ${{ matrix.image }}
@@ -273,8 +273,9 @@ jobs:
     env:
       DEVELOPMENT_CERTIFICATE_DATA_AVAILABLE: ${{ secrets.DEVELOPMENT_CERTIFICATE_DATA != '' }}
       deploy_arch: ${{matrix.image == 'macos-14' && 'osx_arm64' || 'osx64'}}
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
     steps:
-    
+
       - uses: casadi/action-setup-compiler@master
         with:
           cache-suffix: ${{matrix.py2}}
@@ -501,7 +502,7 @@ jobs:
           name: casadi-${{env.os}}${{env.bitness}}-${{matrix.host}}${{matrix.version}}
           path: casadi-${{env.os}}${{env.bitness}}-${{matrix.host}}${{matrix.version}}.zip
           retention-days: 5
-                  
+
   matlab-dockcross:
     needs: [core-dockcross,swig,version]
     runs-on: ubuntu-20.04
@@ -594,7 +595,7 @@ jobs:
           name: casadi-${{env.os}}${{env.bitness}}-${{matrix.host}}${{matrix.version}}
           path: casadi-${{env.os}}${{env.bitness}}-${{matrix.host}}${{matrix.version}}.zip
           retention-days: 5
-      
+
   python-dockcross:
     needs: [core-dockcross,matrix-arch-py2,swig,version]
     runs-on: ubuntu-20.04

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           CC=clang-${{ matrix.compiler }} FC=gfortran-${{ matrix.compiler }} CXX=clang++-${{ matrix.compiler }} cmake -Bbuild -DWITH_SELFCONTAINED=ON ${{env.build_flags}} -H.
           cmake --build build -v
-          
+
   linux-latest:
     runs-on: ubuntu-22.04
     steps:
@@ -49,6 +49,8 @@ jobs:
 
   macos-latest:
     runs-on: macos-latest
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Build
@@ -58,6 +60,8 @@ jobs:
 
   macos-12:
     runs-on: macos-12
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Build
@@ -67,6 +71,8 @@ jobs:
 
   macos-12-clang15:
     runs-on: macos-12
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Build
@@ -99,7 +105,7 @@ jobs:
         run: |
             cmake -Bbuild -G "Visual Studio 17 2022" -A ${{ matrix.arch }} -DWITH_SELFCONTAINED=ON -DCMAKE_INSTALL_PREFIX=install
             cmake --build build --target install --config Release -v
-            
+
   windows-latest-mingw:
     runs-on: windows-latest
     strategy:


### PR DESCRIPTION
## Description

This is a fix for an earlier issue I had opened, which is #3698 – the issue description goes into detail about why this environment variable is needed, but the TLDR is that the CasADi binaries for macOS on PyPI are slightly broken in terms of compatibility since they won't work on macOS 11.0. 11.1 is needed because this target was not set, and `pip` can't install binaries with that deployment target yet (https://github.com/pypa/packaging/issues/578). This isn't fully required, and it isn't a critical issue either – since 11.0 is an old macOS version that the majority of people aren't using, but it is valid in the sense that this bears collision with the Python packaging world.

I am not sure if these additions are going to work for the release binaries or whether I have added this in the right location (please let me know where it would be best to add!), however, since I don't know where the CasADi releases are built and then pushed to PyPI from, it would be nice to test this. It is to be noted that tools such as `cibuildwheel` set this environment variable automatically for Python wheels to achieve maximum compatibility, but integrating that in CasADi's release infrastructure is a larger ask (and task), and cross-compiling binaries with it through Dockcross images is not fully ready, AFAIK.

Fixes #3698

## Additional information

I added this to the `release-3.6.6` branch based on my recent contribution, but I can change the base branch to `main` if needed. It would be great if a workflow that emulates the releases could be triggered for testing. A way to verify the binaries would be to run the [`delocate`](https://github.com/matthew-brett/delocate) tool on the wheel artifact to validate that all of the dynamic libraries are built against this deployment target; this can be done manually, or I can add a sanity check as a step in an appropriate location in the workflows where `delocate` will be able to check it on every build.