### PR TITLE
CMake: add FindSPRAL.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1340,6 +1340,8 @@ if(WITH_SPRAL)
     set(SPRAL_DEPENDS_TARGET spral-external)
     set(SPRAL_FLAGS "--with-spral-cflags=-I${CMAKE_BINARY_DIR}/external_projects/include"
         "--with-spral-lflags=-L${CMAKE_BINARY_DIR}/external_projects/lib -lspral -lgfortran -lm -lcoinmetis ${LAPACK_LFLAGS}")
+  else()
+    set(SPRAL_DEPENDS_TARGET spral::spral)
   endif()
 endif()
 add_feature_info(spral-interface WITH_SPRAL "Interface to SPRAL.")

--- a/cmake/FindSPRAL.cmake
+++ b/cmake/FindSPRAL.cmake
@@ -1,0 +1,24 @@
+find_path(
+  SPRAL_INCLUDE_DIR
+  NAMES spral.h
+  PATHS $ENV{SPRAL})
+find_library(
+  SPRAL_LIBRARY
+  NAMES spral
+  PATHS ${_PREFIX})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SPRAL DEFAULT_MSG SPRAL_LIBRARY
+                                  SPRAL_INCLUDE_DIR)
+mark_as_advanced(SPRAL_INCLUDE_DIR SPRAL_LIBRARY)
+
+if(SPRAL_FOUND AND NOT TARGET spral::spral)
+  add_library(spral::spral SHARED IMPORTED)
+  set_target_properties(
+    spral::spral
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${SPRAL_INCLUDE_DIR}"
+               IMPORTED_LOCATION_RELEASE "${SPRAL_LIBRARY}"
+               IMPORTED_CONFIGURATIONS "RELEASE")
+  message(
+    STATUS "SPRAL found (include: ${SPRAL_INCLUDE_DIR}, lib: ${SPRAL_LIBRARY})")
+endif()


### PR DESCRIPTION
Hi,

This allow use of system SPRAL, which does not provide any `SPRALConfig.cmake` or `spral-config.cmake` for now.