### PR TITLE
#3804: Fix Polynomial constructor

### DIFF
--- a/casadi/core/polynomial.cpp
+++ b/casadi/core/polynomial.cpp
@@ -46,7 +46,7 @@ namespace casadi {
   }
 
   Polynomial::Polynomial(double p0, double p1, double p2, double p3) {
-    p_.resize(2);
+    p_.resize(4);
     p_[0] = p0;
     p_[1] = p1;
     p_[2] = p2;


### PR DESCRIPTION
Spotted in #3804
`Polynomial` does not seem to be exposed in Python/Matlab interface, but it used in the implementation of `collocation_points`, there only the vector coefficient constructor seem to be used.
Should tests be added for those other constructors?