### PR TITLE
Fix build with WITH_FATROP=ON and WITH_BUILD_FATROP=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1194,9 +1194,12 @@ if(WITH_FATROP)
     add_library(fatrop SHARED IMPORTED)
     add_dependencies(fatrop fatrop-external)
     target_link_libraries(fatrop INTERFACE blasfeo)
-    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/external_projects/include/fatrop")
+    # This is similar to ALIAS but works fine on imported targets with CMake 3.10
+    add_library(fatrop::fatrop INTERFACE IMPORTED)
+    set_target_properties(fatrop::fatrop PROPERTIES INTERFACE_LINK_LIBRARIES fatrop)
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/external_projects/include")
     set_target_properties(fatrop PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/external_projects/include/fatrop"
+      INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/external_projects/include"
       IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/external_projects/${SHARED_LIBRARY_RELDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}fatrop${CMAKE_SHARED_LIBRARY_SUFFIX}"
       IMPORTED_IMPLIB "${CMAKE_BINARY_DIR}/external_projects/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}fatrop${CMAKE_IMPORT_LIBRARY_SUFFIX}"
     )

--- a/casadi/interfaces/fatrop/CMakeLists.txt
+++ b/casadi/interfaces/fatrop/CMakeLists.txt
@@ -7,7 +7,7 @@ casadi_plugin(Conic fatrop
   "${CMAKE_CURRENT_BINARY_DIR}/fatrop_conic_runtime_str.h"
   )
 
-casadi_plugin_link_libraries(Conic fatrop fatrop)
+casadi_plugin_link_libraries(Conic fatrop fatrop::fatrop)
 
 casadi_plugin(Nlpsol fatrop
   fatrop_interface.hpp
@@ -16,7 +16,7 @@ casadi_plugin(Nlpsol fatrop
   "${CMAKE_CURRENT_BINARY_DIR}/fatrop_runtime_str.h"
   )
 
-casadi_plugin_link_libraries(Nlpsol fatrop fatrop)
+casadi_plugin_link_libraries(Nlpsol fatrop fatrop::fatrop)
 
 
 #add_executable(fatrop_test fatrop_test.cpp)

--- a/casadi/interfaces/fatrop/fatrop_conic_interface.hpp
+++ b/casadi/interfaces/fatrop/fatrop_conic_interface.hpp
@@ -61,9 +61,9 @@ namespace casadi {
   #include "fatrop_conic_runtime.hpp"
 }
 
-#include <ocp/OCPAbstract.hpp>
-#include <ocp/StageOCPApplication.hpp>
-#include <ocp/OCPCInterface.h>
+#include <fatrop/ocp/OCPAbstract.hpp>
+#include <fatrop/ocp/StageOCPApplication.hpp>
+#include <fatrop/ocp/OCPCInterface.h>
 
 /** \pluginsection{Conic,fatrop} */
 

--- a/casadi/interfaces/fatrop/fatrop_interface.hpp
+++ b/casadi/interfaces/fatrop/fatrop_interface.hpp
@@ -29,9 +29,9 @@
 #include <casadi/interfaces/fatrop/casadi_nlpsol_fatrop_export.h>
 #include "casadi/core/nlpsol_impl.hpp"
 #include "casadi/core/timing.hpp"
-#include <ocp/OCPAbstract.hpp>
-#include <ocp/StageOCPApplication.hpp>
-#include <ocp/OCPCInterface.h>
+#include <fatrop/ocp/OCPAbstract.hpp>
+#include <fatrop/ocp/StageOCPApplication.hpp>
+#include <fatrop/ocp/OCPCInterface.h>
 
 namespace casadi {
   #include "fatrop_runtime.hpp"

--- a/cmake/FindFATROP.cmake
+++ b/cmake/FindFATROP.cmake
@@ -1,0 +1,6 @@
+# Search for fatrop via find_package(fatrop)
+include(CMakeFindDependencyMacro)
+find_dependency(fatrop NO_MODULE)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FATROP DEFAULT_MSG fatrop_FOUND)


### PR DESCRIPTION
Use `fatrop::fatrop` target to link to `fatrop`, and use `#include <fatrop/ocp/OCPAbstract.hpp>`-style includes, for coherence with how fatrop usage is documented in https://github.com/meco-group/fatrop/blob/13d5860ce9866cda000117732b820b8d2b0e65ad/fatrop/executables/RunFatrop.cpp#L22 .