### PR TITLE
fix broken link IPOPT in 90 minutes

### DIFF
--- a/casadi/interfaces/bonmin/bonmin_interface.hpp
+++ b/casadi/interfaces/bonmin/bonmin_interface.hpp
@@ -50,7 +50,7 @@
  * Indeed if bounds on X or constraints are unmet, they will differ.
  *
  * For a good tutorial on BONMIN, see
- * http://drops.dagstuhl.de/volltexte/2009/2089/pdf/09061.WaechterAndreas.Paper.2089.pdf
+ * https://drops.dagstuhl.de/storage/16dagstuhl-seminar-proceedings/dsp-vol09061/DagSemProc.09061.16/DagSemProc.09061.16.pdf
  *
  * A good resource about the algorithms in BONMIN is: Wachter and L. T. Biegler,
  * On the Implementation of an Interior-Point Filter Line-Search Algorithm for

--- a/casadi/interfaces/bonmin/bonmin_interface_meta.cpp
+++ b/casadi/interfaces/bonmin/bonmin_interface_meta.cpp
@@ -34,7 +34,7 @@
 "input(NLPSOL_X0) == output(NLPSOL_X). Indeed if bounds on X or\n"
 "constraints are unmet, they will differ.\n"
 "\n"
-"For a good tutorial on IPOPT, seehttp://drops.dagstuhl.de/volltexte/2009/2089/pdf/09061.WaechterAndreas.Paper.2089.pdf\n"
+"For a good tutorial on IPOPT, seehttps://drops.dagstuhl.de/storage/16dagstuhl-seminar-proceedings/dsp-vol09061/DagSemProc.09061.16/DagSemProc.09061.16.pdf\n"
 "\n"
 "A good resource about the algorithms in IPOPT is: Wachter and L. T.\n"
 "Biegler, On the Implementation of an Interior-Point Filter Line-Search\n"

--- a/casadi/interfaces/ipopt/ipopt_interface.hpp
+++ b/casadi/interfaces/ipopt/ipopt_interface.hpp
@@ -40,7 +40,7 @@
  * Indeed if bounds on X or constraints are unmet, they will differ.
  *
  * For a good tutorial on IPOPT, see
- * http://drops.dagstuhl.de/volltexte/2009/2089/pdf/09061.WaechterAndreas.Paper.2089.pdf
+ * https://drops.dagstuhl.de/storage/16dagstuhl-seminar-proceedings/dsp-vol09061/DagSemProc.09061.16/DagSemProc.09061.16.pdf
  *
  * A good resource about the algorithms in IPOPT is: Wachter and L. T. Biegler,
  * On the Implementation of an Interior-Point Filter Line-Search Algorithm for

--- a/casadi/interfaces/ipopt/ipopt_interface_meta.cpp
+++ b/casadi/interfaces/ipopt/ipopt_interface_meta.cpp
@@ -35,7 +35,7 @@ const std::string meta_doc_0 =
 "input(NLPSOL_X0) == output(NLPSOL_X). Indeed if bounds on X or\n"
 "constraints are unmet, they will differ.\n"
 "\n"
-"For a good tutorial on IPOPT, seehttp://drops.dagstuhl.de/volltexte/2009/2089/pdf/09061.WaechterAndreas.Paper.2089.pdf\n"
+"For a good tutorial on IPOPT, seehttps://drops.dagstuhl.de/storage/16dagstuhl-seminar-proceedings/dsp-vol09061/DagSemProc.09061.16/DagSemProc.09061.16.pdf\n"
 "\n"
 "A good resource about the algorithms in IPOPT is: Wachter and L. T.\n"
 "Biegler, On the Implementation of an Interior-Point Filter Line-Search\n"

--- a/swig/doc.i
+++ b/swig/doc.i
@@ -56452,7 +56452,7 @@ constraints are unmet, they
 will differ.
 
 For a good tutorial on BONMIN, see 
-http://drops.dagstuhl.de/volltexte/2009/2089/pdf/09061.WaechterAndreas.Paper.2089.pdf
+https://drops.dagstuhl.de/storage/16dagstuhl-seminar-proceedings/dsp-vol09061/DagSemProc.09061.16/DagSemProc.09061.16.pdf
 
 A good resource about the algorithms in BONMIN is: Wachter and L. T. 
 
@@ -56673,7 +56673,7 @@ constraints are unmet, they
 will differ.
 
 For a good tutorial on IPOPT, see 
-http://drops.dagstuhl.de/volltexte/2009/2089/pdf/09061.WaechterAndreas.Paper.2089.pdf
+https://drops.dagstuhl.de/storage/16dagstuhl-seminar-proceedings/dsp-vol09061/DagSemProc.09061.16/DagSemProc.09061.16.pdf
 
 A good resource about the algorithms in IPOPT is: Wachter and L. T. 
 


### PR DESCRIPTION
See this issue https://github.com/coin-or/Ipopt/issues/770 . The previous link led to a `Forbidden 403` error.

I already replaced the link in the Wiki in https://github.com/casadi/casadi/wiki/FAQ%3A-how-do-I-learn-more-about-how-Ipopt-works%3F