### PR TITLE
Update FMU demo notebook

### DIFF
--- a/docs/notebooks/fmu_demo.ipynb
+++ b/docs/notebooks/fmu_demo.ipynb
@@ -9,7 +9,7 @@
     "# New FMU interface in CasADi\n",
     "Joel Andersson (joel@jaeandersson.com)\n",
     "\n",
-    "Last updated April 23, 2023"
+    "Last updated October 25, 2024"
    ]
   },
   {
@@ -120,7 +120,7 @@
     "  # Start timer\n",
     "  t1 = time()\n",
     "  # Compile the FMU\n",
-    "  if compiler == 'OCT':    \n",
+    "  if compiler == 'OCT':\n",
     "    # Compile using OCT, cf. OPTIMICA Compiler Toolkit (OCT) User's Guide\n",
     "    from pymodelica import compile_fmu\n",
     "    compiler_options = dict(generate_ode_jacobian = True)\n",
@@ -132,10 +132,10 @@
     "    if omc.loadFile(mofile).startswith('false'):\n",
     "      raise Exception('Modelica compilation failed: {}'.format(omc.sendExpression('getErrorString()')))\n",
     "    omc.sendExpression('setDebugFlags(\"-disableDirectionalDerivatives\")')\n",
-    "    fmu_file = omc.sendExpression('translateModelFMU({})'.format('vdp'))\n",
+    "    fmu_file = omc.sendExpression('buildModelFMU ({})'.format('vdp'))\n",
     "    flag = omc.sendExpression('getErrorString()')\n",
     "    if not fmu_file.endswith('.fmu'): raise Exception('FMU generation failed: {}'.format(flag))\n",
-    "    print(\"translateModelFMU warnings:\\n{}\".format(flag))\n",
+    "    print(\"buildModelFMU  warnings:\\n{}\".format(flag))\n",
     "  else:\n",
     "    raise Exception('Unknown compiler: ' + compiler)\n",
     "  # Output results of compilation\n",
@@ -236,8 +236,7 @@
    "id": "205b9599",
    "metadata": {},
    "source": [
-    "As of this writing, we have successfully imported FMUs with analytic derivatives generated in Dymola and OCT, but *not* in OpenModelica.\n",
-    "If someone knows how to fix the OpenModelica FMU compilation snippet above to enable analytic derivatives, please send an email to joel@jaeandersson.com.\n",
+    "As of this writing, we have successfully imported FMUs with analytic derivatives generated in Dymola, OCT, and OpenModelica.\n",
     "We can proceed with the rest of the demo without analytic derivatives, but we do not recommend to rely on finite differences like this in actual applications."
    ]
   },


### PR DESCRIPTION
# Description 

* Compiling `vdp.mo` into an FMU with OpenModelica and importing it to CasADi now gives analytic derivatives, likely due to 3da9437ff60c9cb442f18db73afff6fc53074d72. The notebook's text is updated to reflect this.
* Replace [the deprecated]( https://github.com/OpenModelica/OpenModelica/pull/10866) `translateModelFMU` with `buildModelFMU`
* Change the date since the last update

# Other 
I ran the notebook on Ubuntu 22.04.4 LTS (WSL)

```bash
omc --version                                                                                                                                                                                   
OpenModelica 1.24.0~2-g7057704
```