### PR TITLE
Function call nodes in SX

### DIFF
--- a/casadi/core/CMakeLists.txt
+++ b/casadi/core/CMakeLists.txt
@@ -117,6 +117,8 @@ set(CASADI_INTERNAL
   constant_sx.hpp                                    # A constant SXElem node
   unary_sx.hpp                                       # A unary operation
   binary_sx.hpp                                      # A binary operation
+  output_sx.hpp
+  call_sx.hpp
 
   # More general graph representation with sparse matrix expressions and function evaluations
   mx.cpp                  # Symbolic expression class (matrix-valued atomics)

--- a/casadi/core/calculus.hpp
+++ b/casadi/core/calculus.hpp
@@ -1631,6 +1631,8 @@ case OP_HYPOT:     DerBinaryOperation<OP_HYPOT>::derf(X, Y, F, D);      break;
       CASADI_MATH_BINARY_BUILTIN
       case OP_IF_ELSE_ZERO:
         return 2;
+      case OP_CALL:
+        return -1;
       default:
         return 1;
     }

--- a/casadi/core/call_sx.hpp
+++ b/casadi/core/call_sx.hpp
@@ -1,0 +1,106 @@
+/*
+ *    This file is part of CasADi.
+ *
+ *    CasADi -- A symbolic framework for dynamic optimization.
+ *    Copyright (C) 2010-2014 Joel Andersson, Joris Gillis, Moritz Diehl,
+ *                            K.U. Leuven. All rights reserved.
+ *    Copyright (C) 2011-2014 Greg Horn
+ *
+ *    CasADi is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation; either
+ *    version 3 of the License, or (at your option) any later version.
+ *
+ *    CasADi is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public
+ *    License along with CasADi; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+
+#ifndef CASADI_CALL_SX_HPP
+#define CASADI_CALL_SX_HPP
+
+#include "sx_node.hpp"
+#include "function.hpp"
+#include <deque>
+#include <stack>
+
+/// \cond INTERNAL
+namespace casadi {
+
+class CallSX : public SXNode {
+  private:
+
+    /** \brief  Constructor is private, use "create" below */
+    CallSX(const Function& f, const std::vector<SXElem>& dep) :
+        f_(f), dep_(dep) {}
+
+  public:
+
+    /** \brief  Create a binary expression */
+    inline static SXElem create(const Function& f, const std::vector<SXElem>& dep) {
+      casadi_assert(f.nnz_in()==dep.size(),
+        "CallSX::create(f,dep): dimension mismatch: " + str(f.nnz_in()) + " vs " + str(dep.size()));
+      return SXElem::create(new CallSX(f, dep));
+    }
+
+    /** \brief Destructor
+    This is a rather complex destructor which is necessary since the default destructor
+    can cause stack overflow due to recursive calling.
+    */
+    ~CallSX() override {
+      for (auto & d  : dep_)
+        safe_delete(d.assignNoDelete(casadi_limits<SXElem>::nan));
+    }
+
+    // Class name
+    std::string class_name() const override {return "CallSX";}
+
+    bool is_op(casadi_int op) const override { return OP_CALL==op; }
+
+    /** \brief  Number of dependencies */
+    casadi_int n_dep() const override { return dep_.size();}
+
+    /** \brief  get the reference of a dependency */
+    const SXElem& dep(casadi_int i) const override { return dep_[i];}
+    SXElem& dep(casadi_int i) override { return dep_[i];}
+
+    /** \brief  Get the operation */
+    casadi_int op() const override { return OP_CALL; }
+
+    /** \brief  Print expression */
+    std::string print(const std::string& arg1, const std::string& arg2) const override {
+      return "call";
+    }
+
+    Function f_;
+
+    /** \brief  The dependencies of the node */
+    std::vector<SXElem> dep_;
+
+    void serialize_node(SerializingStream& s) const override {
+      s.pack("CallSX::f", f_);
+      s.pack("CallSX::dep", dep_);
+    }
+
+    static SXNode* deserialize(DeserializingStream& s) {
+      std::vector<SXElem> dep;
+      Function f;
+      s.unpack("CallSX::f", f);
+      s.unpack("CallSX::dep", dep);
+      return new CallSX(f, dep);
+    }
+
+};
+
+
+} // namespace casadi
+/// \endcond
+
+#endif // CASADI_CALL_SX_HPP

--- a/casadi/core/code_generator.hpp
+++ b/casadi/core/code_generator.hpp
@@ -242,7 +242,7 @@ namespace casadi {
     /** \brief Avoid stack?
 
         \identifier{si} */
-    bool avoid_stack() { return avoid_stack_;}
+    bool avoid_stack() const { return avoid_stack_;}
 
     /** \brief Print a constant in a lossless but compact manner
 

--- a/casadi/core/function_internal.cpp
+++ b/casadi/core/function_internal.cpp
@@ -2458,19 +2458,15 @@ namespace casadi {
     // Codegen sparsities
     codegen_sparsities(g);
 
-    // Determine work vector size
-    casadi_int sz_w_codegen = sz_w();
-    if (is_a("SXFunction", true) && !g.avoid_stack()) sz_w_codegen = 0;
-
     // Function that returns work vector lengths
     g << g.declare(
         "int " + name_ + "_work(casadi_int *sz_arg, casadi_int* sz_res, "
         "casadi_int *sz_iw, casadi_int *sz_w)")
       << " {\n"
-      << "if (sz_arg) *sz_arg = " << sz_arg() << ";\n"
-      << "if (sz_res) *sz_res = " << sz_res() << ";\n"
-      << "if (sz_iw) *sz_iw = " << sz_iw() << ";\n"
-      << "if (sz_w) *sz_w = " << sz_w_codegen << ";\n"
+      << "if (sz_arg) *sz_arg = " << codegen_sz_arg(g) << ";\n"
+      << "if (sz_res) *sz_res = " << codegen_sz_res(g) << ";\n"
+      << "if (sz_iw) *sz_iw = " << codegen_sz_iw(g) << ";\n"
+      << "if (sz_w) *sz_w = " << codegen_sz_w(g) << ";\n"
       << "return 0;\n"
       << "}\n\n";
 
@@ -2479,20 +2475,20 @@ namespace casadi {
         "int " + name_ + "_work_bytes(casadi_int *sz_arg, casadi_int* sz_res, "
         "casadi_int *sz_iw, casadi_int *sz_w)")
       << " {\n"
-      << "if (sz_arg) *sz_arg = " << sz_arg() << "*sizeof(const casadi_real*);\n"
-      << "if (sz_res) *sz_res = " << sz_res() << "*sizeof(casadi_real*);\n"
-      << "if (sz_iw) *sz_iw = " << sz_iw() << "*sizeof(casadi_int);\n"
-      << "if (sz_w) *sz_w = " << sz_w_codegen << "*sizeof(casadi_real);\n"
+      << "if (sz_arg) *sz_arg = " << codegen_sz_arg(g) << "*sizeof(const casadi_real*);\n"
+      << "if (sz_res) *sz_res = " << codegen_sz_res(g) << "*sizeof(casadi_real*);\n"
+      << "if (sz_iw) *sz_iw = " << codegen_sz_iw(g) << "*sizeof(casadi_int);\n"
+      << "if (sz_w) *sz_w = " << codegen_sz_w(g) << "*sizeof(casadi_real);\n"
       << "return 0;\n"
       << "}\n\n";
 
     // Also add to header file to allow getting
      if (g.with_header) {
       g.header
-        << "#define " << name_ << "_SZ_ARG " << sz_arg() << "\n"
-        << "#define " << name_ << "_SZ_RES " << sz_res() << "\n"
-        << "#define " << name_ << "_SZ_IW " << sz_iw() << "\n"
-        << "#define " << name_ << "_SZ_W " << sz_w() << "\n";
+        << "#define " << name_ << "_SZ_ARG " << codegen_sz_arg(g) << "\n"
+        << "#define " << name_ << "_SZ_RES " << codegen_sz_res(g) << "\n"
+        << "#define " << name_ << "_SZ_IW " << codegen_sz_iw(g) << "\n"
+        << "#define " << name_ << "_SZ_W " << codegen_sz_w(g) << "\n";
      }
 
     // Which inputs are differentiable
@@ -2802,6 +2798,19 @@ namespace casadi {
     sz_res = this->sz_res();
     sz_iw = this->sz_iw();
     sz_w = this->sz_w();
+  }
+
+  size_t FunctionInternal::codegen_sz_arg(const CodeGenerator& g) const {
+    return sz_arg();
+  }
+  size_t FunctionInternal::codegen_sz_res(const CodeGenerator& g) const {
+    return sz_res();
+  }
+  size_t FunctionInternal::codegen_sz_iw(const CodeGenerator& g) const {
+    return sz_iw();
+  }
+  size_t FunctionInternal::codegen_sz_w(const CodeGenerator& g) const {
+    return sz_w();
   }
 
   void FunctionInternal::alloc_arg(size_t sz_arg, bool persistent) {

--- a/casadi/core/function_internal.hpp
+++ b/casadi/core/function_internal.hpp
@@ -1147,6 +1147,14 @@ namespace casadi {
         \identifier{n3} */
     size_t sz_w() const { return sz_w_per_ + sz_w_tmp_;}
 
+    /** \brief Get required lengths, for codegen */
+    /// @{
+    virtual size_t codegen_sz_arg(const CodeGenerator& g) const;
+    virtual size_t codegen_sz_res(const CodeGenerator& g) const;
+    virtual size_t codegen_sz_iw(const CodeGenerator& g) const;
+    virtual size_t codegen_sz_w(const CodeGenerator& g) const;
+    /// @}
+
     /** \brief Ensure required length of arg field
 
         \identifier{n4} */

--- a/casadi/core/matrix_decl.hpp
+++ b/casadi/core/matrix_decl.hpp
@@ -498,6 +498,7 @@ namespace casadi {
 #endif // SWIG
 
     Matrix<Scalar> printme(const Matrix<Scalar>& y) const;
+    Matrix<Scalar> call_fun(const Function& f) const;
 
     /// Transpose the matrix
     Matrix<Scalar> T() const;

--- a/casadi/core/matrix_impl.hpp
+++ b/casadi/core/matrix_impl.hpp
@@ -1068,6 +1068,12 @@ namespace casadi {
   }
 
   template<typename Scalar>
+  Matrix<Scalar> Matrix<Scalar>::call_fun(const Function& f) const {
+    casadi_error("Not implemented");
+    //return binary(OP_PRINTME, *this, y);
+  }
+
+  template<typename Scalar>
   void Matrix<Scalar>::erase(const std::vector<casadi_int>& rr,
       const std::vector<casadi_int>& cc, bool ind1) {
     // Erase from sparsity pattern

--- a/casadi/core/output_sx.hpp
+++ b/casadi/core/output_sx.hpp
@@ -1,0 +1,105 @@
+/*
+ *    This file is part of CasADi.
+ *
+ *    CasADi -- A symbolic framework for dynamic optimization.
+ *    Copyright (C) 2010-2014 Joel Andersson, Joris Gillis, Moritz Diehl,
+ *                            K.U. Leuven. All rights reserved.
+ *    Copyright (C) 2011-2014 Greg Horn
+ *
+ *    CasADi is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation; either
+ *    version 3 of the License, or (at your option) any later version.
+ *
+ *    CasADi is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public
+ *    License along with CasADi; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+
+#ifndef CASADI_OUTPUT_SX_HPP
+#define CASADI_OUTPUT_SX_HPP
+
+#include "sx_node.hpp"
+
+/// \cond INTERNAL
+namespace casadi {
+
+    class CASADI_EXPORT OutputSX : public SXNode {
+  private:
+
+    /** \brief  Constructor */
+    OutputSX(const SXElem& dep, int oind) : dep_(dep), oind_(oind) {
+
+    }
+
+  public:
+    /** \brief  Create a unary expression */
+    inline static SXElem create(const SXElem& dep, int oind) {
+      return SXElem::create(new OutputSX(dep, oind));
+    }
+
+    // Class name
+    std::string class_name() const override {return "OutputSX";}
+
+    /** \brief  Print expression */
+    std::string print(const std::string& arg1, const std::string& arg2) const override {
+      return "output(" + arg1 + "," + str(oind_) + ")";
+    }
+
+    /** \brief  Destructor */
+    ~OutputSX() override {
+      safe_delete(dep_.assignNoDelete(casadi_limits<SXElem>::nan));
+    }
+
+    /** \brief Get the operation */
+    casadi_int op() const override { return -1;}
+
+    /** \brief  Number of dependencies */
+    casadi_int n_dep() const override { return 1;}
+
+    /** \brief  get the reference of a dependency */
+    const SXElem& dep(casadi_int i) const override { return dep_; }
+    SXElem& dep(casadi_int i) override { return dep_; }
+
+    /** \brief  The dependencies of the node */
+    SXElem dep_;
+
+    /** \brief  Output index */
+    int oind_;
+
+    static std::vector<SXElem> split(const SXElem& e, casadi_int n) {
+      std::vector<SXElem> ret(n);
+      for (casadi_int i=0;i<n;++i) {
+        ret[i] = OutputSX::create(e, i);
+        // Optimization: get_output() cached like in MultipleOutput
+      }
+      return ret;
+    }
+
+    void serialize_node(SerializingStream& s) const override {
+      s.pack("OutputSX::dep", dep_);
+      s.pack("OutputSX::oind", oind_);
+    }
+
+    static SXNode* deserialize(DeserializingStream& s) {
+      SXElem dep;
+      int oind;
+      s.unpack("OutputSX::dep", dep);
+      s.unpack("OutputSX::oind", oind);
+      return new OutputSX(dep, oind);
+    }
+
+  };
+
+
+} // namespace casadi
+/// \endcond
+
+#endif // CASADI_OUTPUT_SX_HPP

--- a/casadi/core/sx_elem.cpp
+++ b/casadi/core/sx_elem.cpp
@@ -32,6 +32,8 @@
 #include "symbolic_sx.hpp"
 #include "unary_sx.hpp"
 #include "binary_sx.hpp"
+#include "call_sx.hpp"
+#include "output_sx.hpp"
 #include "global_options.hpp"
 #include "sx_function.hpp"
 
@@ -391,6 +393,11 @@ namespace casadi {
       }
     }
     return BinarySX::create(Operation(op), x, y);
+  }
+
+  std::vector<SXElem> SXElem::call_fun(const Function& f, const std::vector<SXElem>& deps) {
+    SXElem c = CallSX::create(f, deps);
+    return OutputSX::split(c, f.nnz_out());
   }
 
   SXElem SXElem::unary(casadi_int op, const SXElem& x) {

--- a/casadi/core/sx_elem.hpp
+++ b/casadi/core/sx_elem.hpp
@@ -147,6 +147,7 @@ namespace casadi {
         \identifier{10p} */
     static SXElem binary(casadi_int op, const SXElem& x, const SXElem& y);
     static SXElem unary(casadi_int op, const SXElem& x);
+    static std::vector<SXElem> call_fun(const Function& f, const std::vector<SXElem>& deps);
 
     /** \brief Check the truth value of this node
 

--- a/casadi/core/sx_function.cpp
+++ b/casadi/core/sx_function.cpp
@@ -135,6 +135,11 @@ namespace casadi {
     }
   }
 
+  size_t SXFunction::codegen_sz_w(const CodeGenerator& g) const {
+    if (!g.avoid_stack()) return 0;
+    return sz_w();
+  }
+
   void SXFunction::codegen_declarations(CodeGenerator& g) const {
 
     // Make sure that there are no free variables

--- a/casadi/core/sx_function.hpp
+++ b/casadi/core/sx_function.hpp
@@ -260,6 +260,9 @@ class CASADI_EXPORT SXFunction :
       \identifier{v3} */
   void init(const Dict& opts) override;
 
+  /** \brief  Get the size of the work vector, for codegen */
+  size_t codegen_sz_w(const CodeGenerator& g) const override;
+
   /** \brief Generate code for the declarations of the C function
 
       \identifier{v4} */

--- a/casadi/core/sx_instantiator.cpp
+++ b/casadi/core/sx_instantiator.cpp
@@ -882,6 +882,8 @@ namespace casadi {
           // Missing simplifications like [x+y]->[twice]
           switch (a.op) {
             CASADI_MATH_FUN_BUILTIN(w[a.i1], w[a.i2], f)
+            default:
+              casadi_error("Not implemented");
           }
 
           std::string key = s.pack(f);
@@ -1351,6 +1353,12 @@ namespace casadi {
     }
 
     return vertcat(ret);
+  }
+
+  template<>
+  SX SX::call_fun(const Function& f) const {
+    std::vector<SXElem> r = SXElem::call_fun(f, nonzeros());
+    return SX(r);
   }
 
   template<>

--- a/casadi/core/sx_node.cpp
+++ b/casadi/core/sx_node.cpp
@@ -29,6 +29,8 @@
 #include "binary_sx.hpp"
 #include "constant_sx.hpp"
 #include "symbolic_sx.hpp"
+#include "call_sx.hpp"
+#include "output_sx.hpp"
 
 #include <limits>
 #include <stack>
@@ -129,14 +131,25 @@ namespace casadi {
       return ss.str();
     }
 
-    // Get expressions for dependencies
-    std::string arg[2];
-    for (casadi_int i=0; i<n_dep(); ++i) {
-      arg[i] = dep(i)->print_compact(nodeind, intermed);
-    }
+    std::string s;
+    if (op()==OP_CALL) {
+      // Get expressions for dependencies
+      s = "call(";
+      for (casadi_int i=0; i<n_dep(); ++i) {
+        s+= dep(i)->print_compact(nodeind, intermed);
+        if (i<n_dep()-1) s+=",";
+      }
+      s += ")";
+    } else {
+      // Get expressions for dependencies
+      std::string arg[2];
+      for (casadi_int i=0; i<n_dep(); ++i) {
+        arg[i] = dep(i)->print_compact(nodeind, intermed);
+      }
 
-    // Get expression for this
-    std::string s = print(arg[0], arg[1]);
+      // Get expression for this
+      s = print(arg[0], arg[1]);
+    }
 
     // Decide what to do with the expression
     if (ind==0) {
@@ -228,7 +241,9 @@ namespace casadi {
   // Note: binary/unary operations are omitted here
   std::map<casadi_int, SXNode* (*)(DeserializingStream&)> SXNode::deserialize_map = {
     {OP_PARAMETER, SymbolicSX::deserialize},
-    {OP_CONST, ConstantSX_deserialize}};
+    {OP_CONST, ConstantSX_deserialize},
+    {OP_CALL, CallSX::deserialize},
+    {-1, OutputSX::deserialize}};
 
 
 } // namespace casadi

--- a/test/python/helpers.py
+++ b/test/python/helpers.py
@@ -697,7 +697,7 @@ class casadiTestCase(unittest.TestCase):
       if opts is None: opts = {}
       return (external(name, libname,opts),libname)
 
-  def check_codegen(self,F,inputs=None, opts=None,std="c89",extralibs="",check_serialize=False,extra_options=None,main=False,main_return_code=0,definitions=None,with_jac_sparsity=False,external_opts=None,with_reverse=False,with_forward=False,extra_include=[],digits=15):
+  def check_codegen(self,F,inputs=None, opts=None,std="c89",extralibs="",check_serialize=False,extra_options=None,main=False,main_return_code=0,definitions=None,with_jac_sparsity=False,external_opts=None,with_reverse=False,with_forward=False,extra_include=[],digits=15,debug_mode=False):
     if not isinstance(main_return_code,list):
         main_return_code = [main_return_code]
     if args.run_slow:
@@ -757,7 +757,10 @@ class casadiTestCase(unittest.TestCase):
         else:
           defs = " ".join(["-D"+d for d in definitions])
           output = "./" + name + (".so" if shared else "")
-          commands = "gcc -pedantic -std={std} -fPIC {shared} -Wall -Werror -Wextra {includedir} -Wno-unknown-pragmas -Wno-long-long -Wno-unused-parameter -O3 {definitions} {name}.c -o {name_out} -L{libdir} -Wl,-rpath,{libdir} -Wl,-rpath,.".format(shared="-shared" if shared else "",std=std,name=name,name_out=name+(".so" if shared else ""),libdir=libdir,includedir=" ".join(["-I" + e for e in includedirs]),definitions=defs) + (" -lm" if not shared else "") + extralibs + extra_options
+          flags = "-O3"
+          if debug_mode:
+            flags = "-O0 -g"
+          commands = "gcc -pedantic -std={std} -fPIC {shared} -Wall -Werror -Wextra {includedir} -Wno-unknown-pragmas -Wno-long-long -Wno-unused-parameter {flags} {definitions} {name}.c -o {name_out} -L{libdir} -Wl,-rpath,{libdir} -Wl,-rpath,.".format(shared="-shared" if shared else "",std=std,name=name,name_out=name+(".so" if shared else ""),libdir=libdir,includedir=" ".join(["-I" + e for e in includedirs]),definitions=defs,flags=flags) + (" -lm" if not shared else "") + extralibs + extra_options
           if sys.platform=="darwin":
             commands+= " -Xlinker -rpath -Xlinker {libdir}".format(libdir=libdir)
             commands+= " -Xlinker -rpath -Xlinker .".format(libdir=libdir)


### PR DESCRIPTION
Allows to embed arbitrarily shaped Functions into an SX graph.

 * Does not touch `ScalarAtomic / SXAlg`, instead, extra info is store in a separate data structure in SXFunction
 * Introduces SX Nodes `CallSX` and `OutputSX`
 * Just like MX OutputNode, `OutputSX` has op -1 and is disregarded when sorting into an algorithm.
 * Primary use-case: multi-dimensional lookup tables

Sample outputs from unittests:

```
Algorithm:
@0 = input[0][0];
@1 = input[1][0];
@2 = (@0/@1);
@3 = input[0][1];
@3 = (@3/@1);
@4 = input[0][2];
@4 = (@4/@1);
@5 = 10;
@6 = input[2][0];
@5 = (@5*@6);
@6 = (@1*@6);
[@2,@3,@4,@5,@7] = f(@2,@3,@4,@5,@6);
@8 = (@2*@1);
@8 = (@8-@6);
@8 = sin(@8);
output[0][0] = @8;
```
```c
/* F:(i0[3],i1,i2)->(o0[2],o1[3x2]) */
static int casadi_f0(const casadi_real** arg, casadi_real** res, casadi_int* iw, casadi_real* w, int mem) {
  casadi_real a0, a1, a2, a3, a4, a5, a6, a7, a8;
  a0=arg[0]? arg[0][0] : 0;
  a1=arg[1]? arg[1][0] : 0;
  a2=(a0/a1);
  a3=arg[0]? arg[0][1] : 0;
  a3=(a3/a1);
  a4=arg[0]? arg[0][2] : 0;
  a4=(a4/a1);
  a5=10.;
  a6=arg[2]? arg[2][0] : 0;
  a5=(a5*a6);
  a6=(a1*a6);
  arg[3]=w+18;
  arg[4]=w+21;
  arg[5]=w+22;
  res[2]=w+23;
  res[3]=w+25;
  w[18] = a2;
  w[19] = a3;
  w[20] = a4;
  w[21] = a5;
  w[22] = a6;
  if (casadi_f1(arg+3, res+2, iw, w+0, 0)) return 1;
  a2 = w[23];
  a3 = w[24];
  a4 = w[25];
  a5 = w[26];
  a7 = w[27];
  a8=(a2*a1);
  a8=(a8-a6);
  a8=sin(a8);
  if (res[0]!=0) res[0][0]=a8;
```
