### PR TITLE
Fix null_ptr_on_copy constructor to support C++20

### DIFF
--- a/casadi/core/optistack_internal.hpp
+++ b/casadi/core/optistack_internal.hpp
@@ -35,8 +35,8 @@ namespace casadi {
 template<class T>
 class null_ptr_on_copy {
 public:
-  null_ptr_on_copy<T>() : ptr_(nullptr) {}
-  null_ptr_on_copy<T>(const null_ptr_on_copy<T>& rhs) : ptr_(nullptr) {}
+  null_ptr_on_copy() : ptr_(nullptr) {}
+  null_ptr_on_copy(const null_ptr_on_copy& rhs) : ptr_(nullptr) {}
   void operator=(T* ptr) { ptr_ = ptr; }
   T* operator->() { return ptr_; }
   operator bool() const { return ptr_; }


### PR DESCRIPTION
See https://wg21.cmeerw.net/cwg/issue2237: 

> Change: A simple-template-id is no longer valid as the declarator-id of a constructor or destructor.
> Rationale: Remove potentially error-prone option for redundancy.
> Effect on original feature: Valid C++ 2017 code may fail to compile.