### PR TITLE
python/tools/graph: Fix SyntaxWarning in operator escaping code

### DIFF
--- a/swig/python/tools/graph/graph.py
+++ b/swig/python/tools/graph/graph.py
@@ -40,7 +40,7 @@ def print_operator_escaped(expr, strs):
   strs = [ si.replace('<', '{').replace('>', '}') for si in strs ]
   s = print_operator(expr, strs)
   # escape < or >
-  s = s.replace('<', '\<').replace('>', '\>')
+  s = s.replace('<', r'\<').replace('>', r'\>')
   # replace {f} with <f>
   s = s.replace('{', '<').replace('}', '>')
   return s


### PR DESCRIPTION
Python gives the warning

  invalid escape sequence '\>'

We need to tell Python that we are not intending to escape any characters in that string, by making it a raw string (prepending with 'r'). Otherwise it looks like we are trying to escape the ">" character.

Note that the code does still work, it just raises a SyntaxWarning which can trip up e.g. `python -m compileall` commands in Docker builds, as those will return with a non-zero exit code.