### PR TITLE
[DRAFT] Add optional support to build against osqp>=1.0.0

### DIFF
--- a/casadi/interfaces/osqp/CMakeLists.txt
+++ b/casadi/interfaces/osqp/CMakeLists.txt
@@ -9,6 +9,27 @@ casadi_plugin(Conic osqp
 
 casadi_plugin_link_libraries(Conic osqp osqp::osqp)
 
+
+if(NOT WITH_BUILD_OSQP)
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/try-osqp-v1.cpp"
+"#include <osqp_api_functions.h>
+
+int main()
+{
+  // This function is only available in OSQP >= 1.0.0
+  OSQPCscMatrix_set_data(nullptr, 0, 0, 0, nullptr, 0, 0);
+  return 0;
+}")
+
+  if(NOT DEFINED WITH_OSQP_V1)
+    try_compile(WITH_OSQP_V1 ${CMAKE_CURRENT_BINARY_DIR} "${CMAKE_CURRENT_BINARY_DIR}/try-osqp-v1.cpp" LINK_LIBRARIES osqp::osqp)
+  endif()
+
+  if(WITH_OSQP_V1)
+    target_compile_definitions(casadi_conic_osqp PRIVATE WITH_OSQP_V1)
+  endif()
+endif()
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 set_target_properties(casadi_conic_osqp PROPERTIES COMPILE_FLAGS "-Wno-unused-variable -Wno-unknown-warning-option")
 endif()

--- a/casadi/interfaces/osqp/osqp_interface.cpp
+++ b/casadi/interfaces/osqp/osqp_interface.cpp
@@ -26,6 +26,23 @@
 #include "osqp_interface.hpp"
 #include "casadi/core/casadi_misc.hpp"
 
+#ifdef WITH_OSQP_V1
+typedef OSQPInt c_int;
+typedef OSQPFloat c_float;
+typedef OSQPCscMatrix csc;
+
+struct OSQPData
+{
+  OSQPInt n; ///< number of variables n
+  OSQPInt m; ///< number of constraints m
+  OSQPCscMatrix * P; ///< the upper triangular part of the quadratic objective matrix P (size n x n).
+  OSQPCscMatrix * A; ///< linear constraints matrix A (size m x n)
+  OSQPFloat * q; ///< dense array for linear part of objective function (size n)
+  OSQPFloat * l; ///< dense array for lower bound (size m)
+  OSQPFloat * u; ///< dense array for upper bound (size m)
+};
+#endif
+
 namespace casadi {
 
   extern "C"
@@ -75,7 +92,11 @@ namespace casadi {
     Conic::init(opts);
 
     osqp_set_default_settings(&settings_);
+#ifdef WITH_OSQP_V1
+    settings_.warm_starting = false;
+#else
     settings_.warm_start = false;
+#endif
 
     warm_start_primal_ = true;
     warm_start_dual_ = true;
@@ -118,7 +139,11 @@ namespace casadi {
           } else if (op.first=="delta") {
             settings_.delta = op.second;
           } else if (op.first=="polish") {
+#ifdef WITH_OSQP_V1
+            settings_.polishing = op.second;
+#else
             settings_.polish = op.second;
+#endif
           } else if (op.first=="polish_refine_iter") {
             settings_.polish_refine_iter = op.second;
           } else if (op.first=="verbose") {
@@ -191,7 +216,11 @@ namespace casadi {
     data.u = get_ptr(dummy);
 
     // Setup workspace
-    if (osqp_setup(&m->work, &data, &settings_)) return 1;
+#ifdef WITH_OSQP_V1
+    if(osqp_setup(&m->work, data.P, data.q, data.A, data.l, data.u, data.m, data.n, &settings_)) return 1;
+#else
+    if(osqp_setup(&m->work, &data, &settings_)) return 1;
+#endif
     // if(osqp_setup(&data, &settings_)) return 1;
 
     m->fstats["preprocessing"]  = FStats();
@@ -222,7 +251,11 @@ namespace casadi {
 
     // Set objective
     if (arg[CONIC_G]) {
+#ifdef WITH_OSQP_V1
+      ret = osqp_update_data_vec(m->work, arg[CONIC_G], nullptr, nullptr);
+#else
       ret = osqp_update_lin_cost(m->work, arg[CONIC_G]);
+#endif
       casadi_assert(ret==0, "Problem in osqp_update_lin_cost");
     }
 
@@ -232,7 +265,27 @@ namespace casadi {
     casadi_copy(arg[CONIC_UBX], nx_, w+nx_+na_);
     casadi_copy(arg[CONIC_UBA], na_, w+2*nx_+na_);
 
+#ifdef WITH_OSQP_V1
+    // Convert C++ infinity values to OSQP infinity
+    // OSQP uses a different convention for infinity, and in osqp v1
+    // using casadi_inf make the casadi test fail, see
+    // https://github.com/osqp/osqp/issues/735
+    for (casadi_int i=0; i<2*(nx_+na_); ++i) {
+      if (std::isinf(w[i]) && !std::signbit(w[i]))
+      {
+        w[i] = OSQP_INFTY;
+      } else if (std::isinf(w[i]) && std::signbit(w[i]))
+      {
+        w[i] = -OSQP_INFTY;
+      }
+    }
+#endif
+
+#ifdef WITH_OSQP_V1
+    ret = osqp_update_data_vec(m->work, nullptr, w, w+nx_+na_);
+#else
     ret = osqp_update_bounds(m->work, w, w+nx_+na_);
+#endif
     casadi_assert(ret==0, "Problem in osqp_update_bounds");
 
     // Project Hessian
@@ -253,19 +306,31 @@ namespace casadi {
     }
 
     // Pass Hessian and constraint matrices
+#ifdef WITH_OSQP_V1
+    ret = osqp_update_data_mat(m->work, w, OSQP_NULL, nnzHupp_, A, OSQP_NULL, nnzA_);
+#else
     ret = osqp_update_P_A(m->work, w, nullptr, nnzHupp_, A, nullptr, nnzA_);
+#endif
     casadi_assert(ret==0, "Problem in osqp_update_P_A");
 
 
     if (warm_start_primal_) {
+#ifdef WITH_OSQP_V1
+      ret = osqp_warm_start(m->work, arg[CONIC_X0], nullptr);
+#else
       ret = osqp_warm_start_x(m->work, arg[CONIC_X0]);
+#endif
       casadi_assert(ret==0, "Problem in osqp_warm_start_x");
     }
 
     if (warm_start_dual_) {
       casadi_copy(arg[CONIC_LAM_X0], nx_, w);
       casadi_copy(arg[CONIC_LAM_A0], na_, w+nx_);
+#ifdef WITH_OSQP_V1
+      ret = osqp_warm_start(m->work, nullptr, w);
+#else
       ret = osqp_warm_start_y(m->work, w);
+#endif
       casadi_assert(ret==0, "Problem in osqp_warm_start_y");
     }
 
@@ -359,12 +424,20 @@ namespace casadi {
     g << "settings.eps_dual_inf = " << settings_.eps_dual_inf << ";\n";
     g << "settings.alpha = " << settings_.alpha << ";\n";
     g << "settings.delta = " << settings_.delta << ";\n";
+#ifdef WITH_OSQP_V1
+    g << "settings.polishing = " << settings_.polishing << ";\n";
+#else
     g << "settings.polish = " << settings_.polish << ";\n";
+#endif
     g << "settings.polish_refine_iter = " << settings_.polish_refine_iter << ";\n";
     g << "settings.verbose = " << settings_.verbose << ";\n";
     g << "settings.scaled_termination = " << settings_.scaled_termination << ";\n";
     g << "settings.check_termination = " << settings_.check_termination << ";\n";
+#ifdef WITH_OSQP_V1
+    g << "settings.warm_starting = " << settings_.warm_starting << ";\n";
+#else
     g << "settings.warm_start = " << settings_.warm_start << ";\n";
+#endif
     //g << "settings.time_limit = " << settings_.time_limit << ";\n";
 
     g << "return osqp_setup(&" + codegen_mem(g) + ", &data, &settings)!=0;\n";
@@ -478,12 +551,20 @@ namespace casadi {
     s.unpack("OsqpInterface::settings::eps_dual_inf", settings_.eps_dual_inf);
     s.unpack("OsqpInterface::settings::alpha", settings_.alpha);
     s.unpack("OsqpInterface::settings::delta", settings_.delta);
+#ifdef WITH_OSQP_V1
+    s.unpack("OsqpInterface::settings::polish", settings_.polishing);
+#else
     s.unpack("OsqpInterface::settings::polish", settings_.polish);
+#endif
     s.unpack("OsqpInterface::settings::polish_refine_iter", settings_.polish_refine_iter);
     s.unpack("OsqpInterface::settings::verbose", settings_.verbose);
     s.unpack("OsqpInterface::settings::scaled_termination", settings_.scaled_termination);
     s.unpack("OsqpInterface::settings::check_termination", settings_.check_termination);
+#ifdef WITH_OSQP_V1
+    s.unpack("OsqpInterface::settings::warm_start", settings_.warm_starting);
+#else
     s.unpack("OsqpInterface::settings::warm_start", settings_.warm_start);
+#endif
     //s.unpack("OsqpInterface::settings::time_limit", settings_.time_limit);
   }
 
@@ -508,12 +589,20 @@ namespace casadi {
     s.pack("OsqpInterface::settings::eps_dual_inf", settings_.eps_dual_inf);
     s.pack("OsqpInterface::settings::alpha", settings_.alpha);
     s.pack("OsqpInterface::settings::delta", settings_.delta);
+#ifdef WITH_OSQP_V1
+    s.pack("OsqpInterface::settings::polish", settings_.polishing);
+#else
     s.pack("OsqpInterface::settings::polish", settings_.polish);
+#endif
     s.pack("OsqpInterface::settings::polish_refine_iter", settings_.polish_refine_iter);
     s.pack("OsqpInterface::settings::verbose", settings_.verbose);
     s.pack("OsqpInterface::settings::scaled_termination", settings_.scaled_termination);
     s.pack("OsqpInterface::settings::check_termination", settings_.check_termination);
+#ifdef WITH_OSQP_V1
+    s.pack("OsqpInterface::settings::warm_start", settings_.warm_starting);
+#else
     s.pack("OsqpInterface::settings::warm_start", settings_.warm_start);
+#endif
     //s.pack("OsqpInterface::settings::time_limit", settings_.time_limit);
   }
 

--- a/casadi/interfaces/osqp/osqp_interface.hpp
+++ b/casadi/interfaces/osqp/osqp_interface.hpp
@@ -48,7 +48,11 @@ namespace casadi {
 
   struct CASADI_CONIC_OSQP_EXPORT OsqpMemory : public ConicMemory {
     // Structures
+#ifdef WITH_OSQP_V1
+    OSQPSolver* work;
+#else
     OSQPWorkspace* work;
+#endif
 
     /// Constructor
     OsqpMemory();


### PR DESCRIPTION
This PR adds optional support to build against osqp>=1.0.o when compiling with `WITH_OSQP=ON` and `WITH_BUILD_OSQP=OFF`. The PR does not change the default osqp version used when compiling with with `WITH_OSQP=ON` and `WITH_BUILD_OSQP=ON`, that remains osqp v0.6.3.

The code was migrated based on:
* https://osqp.org/docs/get_started/migration_guide.html
* https://github.com/robotology/osqp-eigen/pull/131, https://github.com/robotology/osqp-eigen/pull/189

Some notes: 
* Several test failed as the code was never converting from the infinity representation used in casadi (`casadi_inf`) and the OSQP representation used in osqp (`OSQP_INFTY`). This change may also make sense with osqp v0.6.3, but it is necessary for osqp v1.0.0 otherwise several tests would fail (see https://github.com/osqp/osqp/issues/735 for an upstream osqp issue on this)
* Some new settings (like `check_dualgap`) have been added in osqp v1.0.0, this PR does not expose them to keep the complexity of the PR at a minimum.

The PR is in draft, as it is still needs to be completed, in particular:
* The codegeneration part needs to be ported as well.
* Running QP-related tests in with `cd test/` and `python python/conic.py` the `test_ still fails with:

~~~
test_postpone_expand (__main__.ConicTests) ... -----------------------------------------------------------------
           OSQP v1.0.0  -  Operator Splitting QP Solver
              (c) The OSQP Developer Team
-----------------------------------------------------------------
problem:  variables n = 1, constraints m = 1
          nnz(P) + nnz(A) = 2
settings: algebra = Built-in,
          OSQPInt = 4 bytes, OSQPFloat = 8 bytes,
          linear system solver = QDLDL v0.1.8,
          eps_abs = 1.0e-03, eps_rel = 1.0e-03,
          eps_prim_inf = 1.0e-04, eps_dual_inf = 1.0e-04,
          rho = 1.00e-01 (adaptive: 50 iterations),
          sigma = 1.00e-06, alpha = 1.60, max_iter = 4000
          check_termination: on (interval 25, duality gap: on),
          time_limit: 1.00e+10 sec,
          scaling: on (10 iterations), scaled_termination: off
          warm starting: off, polishing: off,
-----------------------------------------------------------------
           OSQP v1.0.0  -  Operator Splitting QP Solver
              (c) The OSQP Developer Team
-----------------------------------------------------------------
problem:  variables n = 1, constraints m = 1
          nnz(P) + nnz(A) = 2
settings: algebra = Built-in,
          OSQPInt = 4 bytes, OSQPFloat = 8 bytes,
          linear system solver = QDLDL v0.1.8,
          eps_abs = 1.0e-03, eps_rel = 1.0e-03,
          eps_prim_inf = 1.0e-04, eps_dual_inf = 1.0e-04,
          rho = 1.00e-01 (adaptive: 50 iterations),
          sigma = 1.00e-06, alpha = 1.60, max_iter = 4000
          check_termination: on (interval 25, duality gap: on),
          time_limit: 1.00e+10 sec,
          scaling: on (10 iterations), scaled_termination: off
          warm starting: off, polishing: off,
ERROR in osqp_update_data_mat: new KKT matrix is not quasidefinite
Function solver_qpsol (0x55acb71f7120)
Input 0 (h): -1
Input 1 (g): 1
Input 2 (a): 0x1
Input 3 (lba): 0x1
Input 4 (uba): 0x1
Input 5 (lbx): -inf
Input 6 (ubx): inf
Input 7 (x0): 2
Input 8 (lam_x0): 0
Input 9 (lam_a0): 0x1
Input 10 (q): 0x1
Input 11 (p): 0x0
deltaT __main__.ConicTests.test_postpone_expand: 0.217
~~~

I tried to debug the problem, but it seems that indeed the test tries to solve a non-convex unbounted QP problem, I have no idea why osqp v0.6.3 seems to work with it (somehow finding the maximum instead of the minimum).

However, as I am not sure when I will be able to continue on this, I think it was worth to open the draft PR so that there is a starting point if someone wants to contribute/provide suggestions.
