### PR TITLE
Fix FindEigen3.cmake to support Eigen3 5.0.0

### DIFF
--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -38,16 +38,21 @@ if(NOT Eigen3_FIND_VERSION)
 endif(NOT Eigen3_FIND_VERSION)
 
 macro(_eigen3_check_version)
-  file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
-
-  string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
-  set(EIGEN3_WORLD_VERSION "${CMAKE_MATCH_1}")
-  string(REGEX MATCH "define[ \t]+EIGEN_MAJOR_VERSION[ \t]+([0-9]+)" _eigen3_major_version_match "${_eigen3_version_header}")
-  set(EIGEN3_MAJOR_VERSION "${CMAKE_MATCH_1}")
-  string(REGEX MATCH "define[ \t]+EIGEN_MINOR_VERSION[ \t]+([0-9]+)" _eigen3_minor_version_match "${_eigen3_version_header}")
-  set(EIGEN3_MINOR_VERSION "${CMAKE_MATCH_1}")
-
-  set(EIGEN3_VERSION ${EIGEN3_WORLD_VERSION}.${EIGEN3_MAJOR_VERSION}.${EIGEN3_MINOR_VERSION})
+  # If Eigen3_VERSION is defined, used it instead of trying to parse the version from headers
+  if(DEFINED Eigen3_VERSION)
+    set(EIGEN3_VERSION Eigen3_VERSION)
+  else()
+    file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
+  
+    string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
+    set(EIGEN3_WORLD_VERSION "${CMAKE_MATCH_1}")
+    string(REGEX MATCH "define[ \t]+EIGEN_MAJOR_VERSION[ \t]+([0-9]+)" _eigen3_major_version_match "${_eigen3_version_header}")
+    set(EIGEN3_MAJOR_VERSION "${CMAKE_MATCH_1}")
+    string(REGEX MATCH "define[ \t]+EIGEN_MINOR_VERSION[ \t]+([0-9]+)" _eigen3_minor_version_match "${_eigen3_version_header}")
+    set(EIGEN3_MINOR_VERSION "${CMAKE_MATCH_1}")
+  
+    set(EIGEN3_VERSION ${EIGEN3_WORLD_VERSION}.${EIGEN3_MAJOR_VERSION}.${EIGEN3_MINOR_VERSION})
+  endif()
   if(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
     set(EIGEN3_VERSION_OK FALSE)
   else(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})


### PR DESCRIPTION
Eigen3 5.0.0 was recently released, with changes in the versioning scheme and in the structure of headers. For this reason, the existing code to get the version fails, with errors like:

~~~
2025-10-05T17:49:41.1459171Z [78/432] Performing configure step for 'manif'
2025-10-05T17:49:41.1460796Z FAILED: [code=1] src/manif/CMakeFiles/YCMStamp/manif-configure /home/runner/work/robotology-superbuild/robotology-superbuild/.build/src/manif/CMakeFiles/YCMStamp/manif-configure 
2025-10-05T17:49:41.1468176Z cd /home/runner/work/robotology-superbuild/robotology-superbuild/.build/src/manif && /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/bin/cmake --no-warn-unused-cli "-DCMAKE_PREFIX_PATH:PATH=/home/runner/work/robotology-superbuild/robotology-superbuild/.build/install;/home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default;/home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/x86_64-conda-linux-gnu/sysroot/usr" -DCMAKE_DISABLE_FIND_PACKAGE_PCL:BOOL=ON -DCMAKE_LINKER_TYPE:PATH=MOLD -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTING:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF -DBUILD_PYTHON_BINDINGS:BOOL=ON -DMANIFPY_PKGDIR:PATH=/home/runner/work/robotology-superbuild/robotology-superbuild/.build/install/lib/python3.11/site-packages -GNinja -C/home/runner/work/robotology-superbuild/robotology-superbuild/.build/src/manif/CMakeFiles/YCMTmp/manif-cache-Release.cmake -S /home/runner/work/robotology-superbuild/robotology-superbuild/src/manif -B /home/runner/work/robotology-superbuild/robotology-superbuild/.build/src/manif && /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/bin/cmake -E touch /home/runner/work/robotology-superbuild/robotology-superbuild/.build/src/manif/CMakeFiles/YCMStamp/manif-configure
2025-10-05T17:49:41.1474595Z Not searching for unused variables given on the command line.
2025-10-05T17:49:41.1476143Z loading initial cache file /home/runner/work/robotology-superbuild/robotology-superbuild/.build/src/manif/CMakeFiles/YCMTmp/manif-cache-Release.cmake
2025-10-05T17:49:41.1477392Z CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
2025-10-05T17:49:41.1478106Z   Compatibility with CMake < 3.10 will be removed from a future version of
2025-10-05T17:49:41.1478644Z   CMake.
2025-10-05T17:49:41.1478780Z 
2025-10-05T17:49:41.1479053Z   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
2025-10-05T17:49:41.1479746Z   to tell CMake that the project requires at least <min> but has been updated
2025-10-05T17:49:41.1480346Z   to work with policies introduced by <max> or earlier.
2025-10-05T17:49:41.1480686Z 
2025-10-05T17:49:41.1480691Z 
2025-10-05T17:49:41.1480863Z -- The CXX compiler identification is GNU 13.3.0
2025-10-05T17:49:41.1481313Z -- Detecting CXX compiler ABI info
2025-10-05T17:49:41.1481722Z -- Detecting CXX compiler ABI info - done
2025-10-05T17:49:41.1483015Z -- Check for working CXX compiler: /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/bin/x86_64-conda-linux-gnu-c++ - skipped
2025-10-05T17:49:41.1484134Z -- Detecting CXX compile features
2025-10-05T17:49:41.1484531Z -- Detecting CXX compile features - done
2025-10-05T17:49:41.1484975Z -- Performing Test COMPILER_SUPPORTS_CXX11
2025-10-05T17:49:41.1485456Z -- Performing Test COMPILER_SUPPORTS_CXX11 - Success
2025-10-05T17:49:41.1486809Z -- The compiler /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/bin/x86_64-conda-linux-gnu-c++ has C++11 support.
2025-10-05T17:49:41.1488605Z -- Eigen3 version .. found in /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/include/eigen3, but at least version 2.91.0 is required
2025-10-05T17:49:41.1490584Z CMake Error at /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/share/cmake-4.0/Modules/FindPackageHandleStandardArgs.cmake:227 (message):
2025-10-05T17:49:41.1492019Z   Could NOT find Eigen3 (missing: EIGEN3_VERSION_OK) (Required is at least
2025-10-05T17:49:41.1492565Z   version "2.91.0")
2025-10-05T17:49:41.1493038Z Call Stack (most recent call first):
2025-10-05T17:49:41.1494244Z   /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/share/cmake-4.0/Modules/FindPackageHandleStandardArgs.cmake:591 (_FPHSA_FAILURE_MESSAGE)
2025-10-05T17:49:41.1495774Z   cmake/modules/FindEigen3.cmake:96 (find_package_handle_standard_args)
2025-10-05T17:49:41.1496353Z   CMakeLists.txt:32 (find_package)
~~~

This PR fixes the problem by using the `Eigen3_VERSION` variable (if defined) instead of manually extracting the version from the Eigen3's header files.

xref: https://github.com/robotology/robotology-superbuild/issues/1902
xref: https://github.com/robotology/robotology-superbuild/issues/1903
xref: https://github.com/conda-forge/eigen-feedstock/pull/47