### PR TITLE
use python:maybecall for mtimes

### DIFF
--- a/swig/casadi.i
+++ b/swig/casadi.i
@@ -2634,6 +2634,7 @@ def dcat(args):
 %feature("python:maybecall") casadi_mod;
 %feature("python:maybecall") casadi_copysign;
 %feature("python:maybecall") casadi_constpow;
+%feature("python:maybecall") casadi_mtimes;
 #endif // SWIGPYTHON
 
 #ifdef SWIGMATLAB


### PR DESCRIPTION
For Python3, use the `python:maybecall` feature to support operator overloadding for the `__matmul__` operator (`@`)