### PR TITLE
fix: raise TypeError on SX/MX equality mismatch (#2817)

### DIFF
--- a/swig/casadi.i
+++ b/swig/casadi.i
@@ -4835,9 +4835,17 @@ namespace casadi {
       def __rgt__(x, y): return _casadi.lt(x, y)
       def __ge__(x, y): return _casadi.le(y, x)
       def __rge__(x, y): return _casadi.le(x, y)
-      def __eq__(x, y): return _casadi.eq(x, y)
+      def __eq__(x, y):
+          r = _casadi.eq(x, y)
+          if r is NotImplemented:
+              raise TypeError("Cannot compare " + type(x).__name__ + " and " + type(y).__name__ + " (no SX/MX type promotion)")
+          return r
       def __req__(x, y): return _casadi.eq(y, x)
-      def __ne__(x, y): return _casadi.ne(x, y)
+      def __ne__(x, y):
+          r = _casadi.ne(x, y)
+          if r is NotImplemented:
+              raise TypeError("Cannot compare " + type(x).__name__ + " and " + type(y).__name__ + " (no SX/MX type promotion)")
+          return r
       def __rne__(x, y): return _casadi.ne(y, x)
       def __pow__(x, n): return _casadi.power(x, n)
       def __rpow__(n, x): return _casadi.power(x, n)

--- a/test/python/mx.py
+++ b/test/python/mx.py
@@ -4528,5 +4528,30 @@ class MXtests(casadiTestCase):
                     # qn is non-diff output: no dependencies
                     self.assertEqual(H.sparsity_jac(0,1).nnz(), 0)
 
+  def test_sx_mx_equality_no_silent_promotion(self):
+    # Regression for GH-2817: SX == MX (and the != / reflected forms)
+    # used to fall through SWIG's NotImplemented dispatch and Python's
+    # identity fallback, silently returning False/True. They must error.
+    x = MX.sym('x')
+    z = SX.zeros(1, 1)
+    with self.assertRaises(TypeError):
+      z == x
+    with self.assertRaises(TypeError):
+      x == z
+    with self.assertRaises(TypeError):
+      z != x
+    with self.assertRaises(TypeError):
+      x != z
+
+    # Sanity: same-type and numeric-promotion equality still works.
+    r1 = SX(1) == SX(1)
+    self.assertTrue(isinstance(r1, SX))
+    r2 = MX(1) == MX(1)
+    self.assertTrue(isinstance(r2, MX))
+    r3 = SX(1) == 1.0
+    self.assertTrue(isinstance(r3, SX))
+    r4 = MX(1) == 1.0
+    self.assertTrue(isinstance(r4, MX))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #2817. `SX(...) == MX(...)` silently returned `False` instead of erroring.

## Root cause

The SWIG dispatchers for `eq` / `ne` are generated with `%feature("python:maybecall")` (`swig/casadi.i:2837-2838`), so when no `(double, double) / (DM, DM) / (SX, SX) / (MX, MX)` overload matches the dispatcher's terminal `fail:` returns `Py_NotImplemented`:

```cpp
// generated casadiPYTHON_wrap.cxx:_wrap_eq
fail:
  Py_INCREF(Py_NotImplemented);
  return Py_NotImplemented;
```

For non-equality binops (`+`, `<`, …) Python's protocol turns dual-`NotImplemented` into a `TypeError`, but for `==` / `!=` it falls back to **identity** comparison — silently yielding `False` / `True`. So

```python
x = MX.sym('x')
z = SX.zeros(1, 1)
z == x   # was: False (silent), now: TypeError
```

`==` and `!=` are the only operators with this silent path; an exhaustive scan of every `python:maybecall`-tagged dispatcher confirms the rest (`+ - * / ** < <= > >=`) already raise via Python's protocol.

## Fix

Convert the `NotImplemented` sentinel into a `TypeError` inside `__eq__` / `__ne__` (`swig/casadi.i:4838-4841`):

```python
def __eq__(x, y):
    r = _casadi.eq(x, y)
    if r is NotImplemented:
        raise TypeError(...)
    return r
```

(same for `__ne__`).

## Side effect

`SX(...) == "string"` (or any other unpromotable foreign type) now raises `TypeError` instead of silently returning `False`. Numeric-foreign-type cases (`int`, `float`, numpy scalars/arrays) are unaffected because they already promote to `DM`. `is None` should be used in place of `== None` for symbolic types — that was already the right pattern.

## Test plan

- [ ] `z == x` (SX vs MX) raises `TypeError` instead of returning `False`
- [ ] `z != x` raises `TypeError` instead of returning `True`
- [ ] `SX(1) == SX(1)` still works
- [ ] `MX(1) == MX(1)` still works
- [ ] `SX(1) == 1.0` still works (DM promotion)
- [ ] `SX(1) == np.array([1.0])` still works
- [ ] Existing test suite passes

https://claude.ai/code/session_013WJsS49GVS4E1fo6BRHhBE

---
_Generated by [Claude Code](https://claude.ai/code/session_013WJsS49GVS4E1fo6BRHhBE)_