### PR TITLE
issue #4285: POC multi-wheel split via manifest in create_wheel_local.py

### DIFF
--- a/misc/create_wheel_local.py
+++ b/misc/create_wheel_local.py
@@ -8,6 +8,8 @@ from email.generator import Generator
 import shutil
 import re
 import sys
+import json
+import fnmatch
 
 def open_for_csv(name, mode):
     if sys.version_info[0] < 3:
@@ -18,12 +20,20 @@ def open_for_csv(name, mode):
 
     return open(name, mode, **kwargs)
 
-version   = sys.argv[1]
-pyversion = sys.argv[2]
-os_name   = sys.argv[3]
-bitness   = sys.argv[4]
-arch      = sys.argv[5]
-dir_name  = sys.argv[6]
+# Optional --manifest <path> trailing argument
+manifest_path = None
+argv = list(sys.argv)
+if "--manifest" in argv:
+  i = argv.index("--manifest")
+  manifest_path = argv[i+1]
+  del argv[i:i+2]
+
+version   = argv[1]
+pyversion = argv[2]
+os_name   = argv[3]
+bitness   = argv[4]
+arch      = argv[5]
+dir_name  = argv[6]
 
 
 if "+" in version:
@@ -61,7 +71,7 @@ elif os_name=="windows":
 else:
   raise Exception()
 
-def write_record(bdist_dir, distinfo_dir):        
+def write_record(bdist_dir, distinfo_dir):
 
       record_path = os.path.join(distinfo_dir, 'RECORD')
       record_relpath = os.path.relpath(record_path, bdist_dir)
@@ -92,94 +102,190 @@ def write_record(bdist_dir, distinfo_dir):
               record_path = os.path.relpath(
                   path, bdist_dir).replace(os.path.sep, '/')
               writer.writerow((record_path, hash, size))
-             
-wheel_dist_name = "casadi" + "-" + version
-bdist_dir = dir_name
 
-distinfo_dir = os.path.join(bdist_dir,'%s.dist-info' % wheel_dist_name)
-if not os.path.exists(distinfo_dir):
-  os.mkdir(distinfo_dir)
+def normalize_dist(name):
+  # PEP 427: replace runs of non-alphanumerics with a single underscore
+  return re.sub(r"[-_.]+", "_", name)
 
-for d in os.listdir(dir_name):
-  if not d.startswith("casadi") and os.path.isdir(os.path.join(dir_name, d)):
-    shutil.copytree(os.path.join(dir_name, d),os.path.join(bdist_dir,"casadi",d),dirs_exist_ok=True)
-    shutil.rmtree(os.path.join(dir_name, d))
+def fullname_for(dist_name):
+  base = dist_name + "-" + version
+  if isinstance(tag, list):
+    fn = base + "-" + tag[0]
+    for t in tag[1:]:
+      fn += "." + t.split("-")[-1]
+    return fn
+  return base + "-" + tag
 
-msg = Message()
-msg['Wheel-Version'] = '1.0'  # of the spec
-#msg['Generator'] = generator
-msg['Root-Is-Purelib'] = "false"
-if isinstance(tag,list):
-  for t in tag: msg["Tag"] = t
-else:
-  msg["Tag"] = tag
+def write_wheel_metafiles(bdist_dir, dist_name, summary, description,
+                          requires_dist=None, provides_extra=None):
+  wheel_dist = dist_name + "-" + version
+  distinfo_dir = os.path.join(bdist_dir, '%s.dist-info' % wheel_dist)
+  if not os.path.exists(distinfo_dir):
+    os.mkdir(distinfo_dir)
 
-
-
-wheelfile_path = os.path.join(distinfo_dir, 'WHEEL')
-with open(wheelfile_path, 'w') as f:
+  msg = Message()
+  msg['Wheel-Version'] = '1.0'
+  msg['Root-Is-Purelib'] = "false"
+  if isinstance(tag, list):
+    for t in tag: msg["Tag"] = t
+  else:
+    msg["Tag"] = tag
+  with open(os.path.join(distinfo_dir, 'WHEEL'), 'w') as f:
     Generator(f, maxheaderlen=0).flatten(msg)
 
-metadata_path = os.path.join(distinfo_dir, 'METADATA')
-with open(metadata_path, 'w') as f:
-    f.write("""Metadata-Version: 2.1
-Name: casadi
-Version: %s
-Summary: CasADi -- framework for algorithmic differentiation and numeric optimization
-Home-page: http://casadi.org
-Author: Joel Andersson, Joris Gillis, Greg Horn
-Author-email:  developer_first_name@casadi.org
-License: GNU Lesser General Public License v3 or later (LGPLv3+)
-Download-URL: http://install.casadi.org
-Project-URL: Documentation, http://docs.casadi.org
-Project-URL: Bug Tracker, https://github.com/casadi/casadi/issues
-Project-URL: Source Code, https://github.com/casadi/casadi
-Platform: Windows
-Platform: Linux
-Platform: Mac OS-X
-Classifier: Development Status :: 5 - Production/Stable
-Classifier: Intended Audience :: Science/Research
-Classifier: License :: OSI Approved
-Classifier: Programming Language :: C++
-Classifier: Programming Language :: Python
-Classifier: Programming Language :: Python :: 2
-Classifier: Programming Language :: Python :: 2.7
-Classifier: Programming Language :: Python :: 3
-Classifier: Programming Language :: Python :: 3.4
-Classifier: Programming Language :: Python :: 3.5
-Classifier: Programming Language :: Python :: 3.6
-Classifier: Programming Language :: Python :: 3.6
-Classifier: Programming Language :: Python :: 3.7
-Classifier: Programming Language :: Python :: 3.8
-Classifier: Programming Language :: Python :: 3.9
-Classifier: Programming Language :: Python :: 3.10
-Classifier: Programming Language :: Python :: 3.11
-Classifier: Programming Language :: Python :: 3.12
-Classifier: Programming Language :: Python :: Implementation :: CPython
-Classifier: Topic :: Scientific/Engineering
-Classifier: Operating System :: Microsoft :: Windows
-Classifier: Operating System :: POSIX
-Classifier: Operating System :: Unix
-Classifier: Operating System :: MacOS
-Requires-Dist: numpy
+  lines = [
+    "Metadata-Version: 2.1",
+    "Name: " + dist_name,
+    "Version: " + version,
+    "Summary: " + summary,
+    "Home-page: http://casadi.org",
+    "Author: Joel Andersson, Joris Gillis, Greg Horn",
+    "Author-email:  developer_first_name@casadi.org",
+    "License: GNU Lesser General Public License v3 or later (LGPLv3+)",
+    "Download-URL: http://install.casadi.org",
+    "Project-URL: Documentation, http://docs.casadi.org",
+    "Project-URL: Bug Tracker, https://github.com/casadi/casadi/issues",
+    "Project-URL: Source Code, https://github.com/casadi/casadi",
+    "Platform: Windows",
+    "Platform: Linux",
+    "Platform: Mac OS-X",
+    "Classifier: Development Status :: 5 - Production/Stable",
+    "Classifier: Intended Audience :: Science/Research",
+    "Classifier: License :: OSI Approved",
+    "Classifier: Programming Language :: C++",
+    "Classifier: Programming Language :: Python",
+    "Classifier: Programming Language :: Python :: 3",
+    "Classifier: Programming Language :: Python :: Implementation :: CPython",
+    "Classifier: Topic :: Scientific/Engineering",
+    "Classifier: Operating System :: Microsoft :: Windows",
+    "Classifier: Operating System :: POSIX",
+    "Classifier: Operating System :: Unix",
+    "Classifier: Operating System :: MacOS",
+  ]
+  for r in (requires_dist or []):
+    lines.append("Requires-Dist: " + r)
+  for e in (provides_extra or []):
+    lines.append("Provides-Extra: " + e)
+  lines.append("")
+  lines.append(description)
+  lines.append("")
+  with open(os.path.join(distinfo_dir, 'METADATA'), 'w') as f:
+    f.write("\n".join(lines))
 
-CasADi is a symbolic framework for numeric optimization implementing automatic differentiation in forward and reverse modes on sparse matrix-valued computational graphs. It supports self-contained C-code generation and interfaces state-of-the-art codes such as SUNDIALS, IPOPT etc. It can be used from C++, Python or Matlab/Octave.
+  return distinfo_dir
 
-Example pack can be downloaded from http://install.casadi.org
+# Consolidate non-casadi-prefixed top-level dirs into casadi/ (existing behavior)
+bdist_dir = dir_name
+for d in os.listdir(dir_name):
+  if not d.startswith("casadi") and os.path.isdir(os.path.join(dir_name, d)):
+    shutil.copytree(os.path.join(dir_name, d), os.path.join(bdist_dir, "casadi", d), dirs_exist_ok=True)
+    shutil.rmtree(os.path.join(dir_name, d))
 
-""" % (version))
+# Parse manifest
+plugins = []  # list of dicts: {name, dist_name, normalized, patterns, summary, extras}
+if manifest_path:
+  with open(manifest_path) as f:
+    raw = json.load(f)
+  for name, spec in raw.items():
+    patterns = spec.get("patterns") or spec.get("match") or []
+    if isinstance(patterns, str):
+      patterns = [patterns]
+    plugins.append({
+      "dist_name": name,
+      "normalized": normalize_dist(name),
+      "patterns": patterns,
+      "summary": spec.get("summary", "CasADi plugin: " + name),
+      "extras": spec.get("extras"),  # extras key for main wheel; defaults below
+    })
 
+casadi_pkg = os.path.join(bdist_dir, "casadi")
 
-#wheel_dist_name = wheel_dist_name+".post1"
-if isinstance(tag,list):
-  fullname = wheel_dist_name+"-"+tag[0]
-  for t in tag[1:]:
-    fullname+="."+t.split("-")[-1]
+# For each plugin, carve out matching files into a separate staging dir and build a wheel.
+# Matching is by file basename via fnmatch (case-insensitive on Windows-style; we use plain fnmatch).
+plugin_assignments = {}  # absolute file path -> plugin index (first match wins)
+for idx, plug in enumerate(plugins):
+  for root, _dirs, files in os.walk(casadi_pkg):
+    for fname in files:
+      if any(fnmatch.fnmatchcase(fname, pat) for pat in plug["patterns"]):
+        absp = os.path.join(root, fname)
+        plugin_assignments.setdefault(absp, idx)
+
+built_wheels = []
+plugin_stage_dirs = []
+
+for idx, plug in enumerate(plugins):
+  stage = os.path.join(os.path.dirname(os.path.abspath(bdist_dir)),
+                       "_plugin_stage_" + plug["normalized"])
+  if os.path.exists(stage):
+    shutil.rmtree(stage)
+  os.makedirs(os.path.join(stage, "casadi"))
+  plugin_stage_dirs.append(stage)
+
+  moved_any = False
+  for absp, owner in list(plugin_assignments.items()):
+    if owner != idx:
+      continue
+    rel = os.path.relpath(absp, casadi_pkg)
+    dst = os.path.join(stage, "casadi", rel)
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    shutil.move(absp, dst)
+    moved_any = True
+
+  if not moved_any:
+    sys.stderr.write("[create_wheel] WARNING: plugin %r matched no files\n" % plug["dist_name"])
+
+  desc = "Plugin package for CasADi: %s. Install via casadi[%s]." % (
+    plug["dist_name"], plug["extras"] or plug["dist_name"].replace("casadi-plugin-", ""))
+  write_wheel_metafiles(
+    stage,
+    plug["normalized"],
+    plug["summary"],
+    desc,
+    requires_dist=["casadi==" + version.split("+")[0]],
+  )
+  fullname = fullname_for(plug["normalized"])
+  distinfo_dir = os.path.join(stage, plug["normalized"] + "-" + version + ".dist-info")
+  write_record(stage, distinfo_dir)
+  archive_wheelfile(os.path.join(os.path.dirname(stage), fullname), stage)
+  built_wheels.append(os.path.join(os.path.dirname(stage), fullname) + ".whl")
+
+# Now build the main casadi wheel from whatever remains
+extras_lines = []
+for plug in plugins:
+  extra = plug["extras"] or plug["dist_name"].replace("casadi-plugin-", "")
+  extras_lines.append((extra, plug["dist_name"]))
+
+requires_dist = ["numpy"] + [
+  '%s ; extra == "%s"' % (dist, extra) for extra, dist in extras_lines
+]
+provides_extra = [extra for extra, _ in extras_lines]
+
+main_description = (
+  "CasADi is a symbolic framework for numeric optimization implementing automatic "
+  "differentiation in forward and reverse modes on sparse matrix-valued computational "
+  "graphs. It supports self-contained C-code generation and interfaces state-of-the-art "
+  "codes such as SUNDIALS, IPOPT etc. It can be used from C++, Python or Matlab/Octave.\n\n"
+  "Example pack can be downloaded from http://install.casadi.org"
+)
+
+write_wheel_metafiles(
+  bdist_dir,
+  "casadi",
+  "CasADi -- framework for algorithmic differentiation and numeric optimization",
+  main_description,
+  requires_dist=requires_dist,
+  provides_extra=provides_extra,
+)
+
+main_distinfo = os.path.join(bdist_dir, "casadi-" + version + ".dist-info")
+main_fullname = fullname_for("casadi")
+write_record(bdist_dir, main_distinfo)
+archive_wheelfile(main_fullname, dir_name)
+built_wheels.append(main_fullname + ".whl")
+
+if manifest_path:
+  # multi-wheel mode: print one wheel per line
+  sys.stdout.write("\n".join(built_wheels))
 else:
-  fullname = wheel_dist_name+"-"+tag
-
-write_record(bdist_dir, distinfo_dir)
-archive_wheelfile(fullname,dir_name)
-
-import sys
-sys.stdout.write(fullname+".whl")
+  # back-compat: single wheel filename, no trailing newline
+  sys.stdout.write(main_fullname + ".whl")


### PR DESCRIPTION
## Motivation

`binaries.yml` currently runs `misc/create_wheel_local.py` to package a casadi build
tree into a single monolithic wheel (twice actually — once for `repairwheel`, once for
distribution). The wheel ships every solver/plugin we built (Ipopt, BLAS/LAPACK,
HiGHS, Bonmin, …), so users pay the full download size even when they only want the
core. This PR is a **proof of concept** for splitting that single wheel into a main
wheel plus N optional plugin wheels — with the property that, once installed, the
files end up exactly where they used to be on disk.

Nothing about the build is changed. This only touches the post-build packaging
script.

## What the script does now

`create_wheel_local.py` gains an optional `--manifest <path-to-json>` argument. With
no manifest the behaviour and stdout shape are unchanged (so the existing
`binaries.yml` invocation keeps working). With a manifest, it splits the install
tree into:

- one **main `casadi`** wheel — everything not claimed by a plugin
- one **plugin wheel** per manifest entry — files matching that entry's patterns

### Manifest format

Plain JSON, no extra deps:

```json
{
  "casadi-plugin-blas": {
    "patterns": ["*blas*", "*lapack*"],
    "summary": "BLAS/LAPACK plugin for CasADi"
  },
  "casadi-plugin-ipopt": {
    "patterns": ["*ipopt*"],
    "summary": "IPOPT plugin for CasADi"
  }
}
```

Patterns are `fnmatch` globs matched against file basenames inside `casadi/`.
First match wins, so plugin order in the manifest decides ownership of overlaps.
Anything not matched stays in the main wheel.

## How users install

Two equivalent forms — pip handles both natively:

```
pip install casadi[ipopt]
pip install casadi casadi-plugin-ipopt
```

The `[ipopt]` short name → full distribution name mapping is done entirely in the
**main wheel's METADATA**, which gets emitted with:

```
Provides-Extra: blas
Requires-Dist: casadi-plugin-blas ; extra == "blas"
Provides-Extra: ipopt
Requires-Dist: casadi-plugin-ipopt ; extra == "ipopt"
```

By default the extras short name is the manifest key with the `casadi-plugin-`
prefix stripped; you can override it via an `"extras"` field per entry. Plugin
wheels in turn declare `Requires-Dist: casadi==<version>`.

## Why files end up in one folder on the user side

Nothing clever — it falls out of how wheels work. A wheel is a zip whose top-level
directory names *are* the install destinations. Both wheels are emitted with
`casadi/` as the only top-level data directory (plus their own `*.dist-info/`):

```
casadi-3.7.2-...whl                casadi_plugin_ipopt-3.7.2-...whl
├── casadi/                        ├── casadi/
│   ├── __init__.py                │   ├── libcasadi_nlpsol_ipopt.so
│   ├── _casadi.so                 │   ├── libipopt.so.3
│   └── ...                        │   └── ...
└── casadi-3.7.2.dist-info/        └── casadi_plugin_ipopt-3.7.2.dist-info/
```

Pip just unpacks each wheel into `site-packages/`. Both `casadi/` trees merge into
one `site-packages/casadi/`, while each `*.dist-info/` is separate (so pip can
uninstall them independently via per-wheel `RECORD`).

The only rule pip enforces is that no two installed wheels may own the same file
path. The script guarantees this with first-match-wins assignment in
`plugin_assignments.setdefault(absp, idx)` — a file already claimed by an earlier
plugin can't be claimed by a later one or by the main wheel.

There's no namespace-package trickery (`casadi/__init__.py` lives in the main wheel
only) and no install-time merging.

## Local POC results

Tested by carving the publicly-installed `casadi 3.7.2` Linux package into a fake
`install/casadi/` tree, then running the script with the example manifest above:

| wheel | size |
|---|---|
| `casadi-3.7.2-cp311-none-manylinux2014_x86_64.whl` | 52 MB |
| `casadi_plugin_blas-3.7.2-...whl` | 19 MB |
| `casadi_plugin_ipopt-3.7.2-...whl` | 4 MB |

Verified:

- `pip install` of all three → all files land in one `site-packages/casadi/`;
  `import casadi` works; `nlpsol('s','ipopt',...)` solves an NLP.
- `pip install --find-links . casadi[ipopt,blas]==3.7.2` → pip auto-pulls both
  plugins via the extras and Ipopt loads.
- `pip install casadi-...whl` alone → main works; `nlpsol('s','ipopt',...)`
  correctly fails with `Plugin 'ipopt' is not found`.
- Old call signature with no `--manifest` → produces the same single wheel with
  the same single-line stdout as before (back-compat preserved for
  `binaries.yml`).

## Caveats / things to discuss before this becomes real

- **Cross-plugin runtime deps aren't tracked.** `libcasadi_nlpsol_ipopt.so`
  transitively depends on `libcasadi-tp-openblas.so.0`, so `casadi[ipopt]` without
  `[blas]` installs cleanly but Ipopt fails to `dlopen`. We'd need either (a) put
  both in the same plugin, (b) declare inter-plugin `Requires-Dist`, or
  (c) extend the manifest with explicit deps.
- **Match is on basename only and case-sensitive.** `*blas*` won't catch
  `LinearAlgebraBlasfeo.hpp` (capital `B`) or `openblas-external/LICENSE` (LICENSE
  is the basename). Easy to extend to full-relative-path / case-insensitive
  matching once we decide what we want.
- **`repairwheel` ordering.** Today `binaries.yml` runs `repairwheel` on the
  monolithic wheel. With a split, we either run `repairwheel` per output wheel
  (probably the right thing) or once on the unsplit tree before splitting.
- **Naming bikeshed.** Currently `casadi-plugin-<x>`. Could just as easily be
  `casadi-<x>` or `casadi[<x>]`-only-no-published-plugin (extras can refer to
  arbitrary names, doesn't have to be a real PyPI dist).

## Scope

Single-file change: `misc/create_wheel_local.py`. No CI workflow changes — the
existing `binaries.yml` invocation is unaffected since the new `--manifest` flag
is opt-in. A follow-up would wire a manifest file + the split wheels into
`binaries.yml` once we settle the manifest contents.

Marking as **draft** — this is an experiment to evaluate the approach, not a
ready-to-merge change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQJ3jsqM8eGrShQudPjido)_