### PR TITLE
Fix system METIS detection breaking MUMPS/HSL/SPRAL source builds (#4328)

### DIFF
--- a/cmake/FindMETIS.cmake
+++ b/cmake/FindMETIS.cmake
@@ -36,19 +36,10 @@ if(NOT METIS_FOUND)
 
 
     if(METIS_FOUND)
-        add_library(metis::metis INTERFACE IMPORTED)
+        add_library(metis::metis SHARED IMPORTED)
         set_target_properties(metis::metis PROPERTIES
-          INTERFACE_INCLUDE_DIRECTORIES ${METIS_INCLUDE_DIR}
+          IMPORTED_LOCATION "${METIS_LIB}"
+          INTERFACE_INCLUDE_DIRECTORIES "${METIS_INCLUDE_DIR}"
         )
-        if("${METIS_LIB}" MATCHES "coinmetis")
-            set_target_properties(metis::metis PROPERTIES
-              IMPORTED_LIBNAME coinmetis
-            )
-        else()
-            set_target_properties(metis::metis PROPERTIES
-              IMPORTED_LIBNAME metis
-            )
-        endif()
-        target_link_libraries(metis::metis INTERFACE ${METIS_LIBRARIES})
     endif()
 endif()


### PR DESCRIPTION
## Summary

Fixes #4328: when METIS is found via system install (CONFIG-mode `find_package` fails), `cmake/FindMETIS.cmake` produced an `INTERFACE IMPORTED` target with only `IMPORTED_LIBNAME` set. Since 1f83437c the consumer sites for HSL, MUMPS and SPRAL in `CMakeLists.txt` read `IMPORTED_LOCATION` to derive `METIS_LIB_DIR` / `METIS_LIB_NAME` for the ExternalProject configure flags. With the old target shape `get_target_property` returned `METIS_LIB_PATH-NOTFOUND`, yielding linker flags like `-L -lMETIS_LIB_PATH-NOTFOUND -lm` and the autotools error `user-specified flags for Metis do not work`.

Switch the system-found path to `SHARED IMPORTED` with `IMPORTED_LOCATION` set to the `find_library` result. This matches the shape used by the source-build path at `CMakeLists.txt:1507` and the contract the three consumer sites already rely on.

## Reproduction (before fix)

```
cmake -DWITH_MUMPS=ON -DWITH_BUILD_MUMPS=ON ..
make
# ...
# configure: error: user-specified flags for Metis do not work.
```

`mumps-external/config.log`:
```
gcc -o conftest -O2 -DNDEBUG  -I/usr/include  conftest.c -L -lMETIS_LIB_PATH-NOTFOUND -lm >&5
```

## After fix

`mumps-external/config.log`:
```
gcc -o conftest -O2 -DNDEBUG  -I/usr/include  conftest.c -L/usr/lib/x86_64-linux-gnu -lmetis -lm >&5
configure:20756: $? = 0
configure:20800: result: yes
```

Full `make` reaches 100% with `libcoinmumps.so.3.0.11` and `libcasadi_linsol_mumps.so.3.7` produced.

## Test plan

- [x] `cmake -DWITH_MUMPS=ON -DWITH_BUILD_MUMPS=ON ..` configures cleanly with system-installed METIS (`libmetis-dev`).
- [x] MUMPS ExternalProject configure passes `checking for library Metis` (result: yes).
- [x] Full build to 100% with no errors.
- [ ] CI green for the same matrix that surfaced #4328.

Notes:
- The same `IMPORTED_LIBNAME` antipattern is not present in any other `Find*.cmake` module (verified via grep), so this regression is METIS-specific.
- `WITH_BUILD_METIS=ON` (source-build) path was not exercised in this verification; it was unaffected by the bug since `CMakeLists.txt:1507` already sets `IMPORTED_LOCATION`.

https://claude.ai/code/session_01Uw2RvKveCYWPDgLCkApybD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uw2RvKveCYWPDgLCkApybD)_