### PR TITLE
issue #3371: collocation forward+adjoint sensitivities wrong for nfwd>1

### DIFF
--- a/casadi/core/integrator.cpp
+++ b/casadi/core/integrator.cpp
@@ -2174,6 +2174,11 @@ void FixedStepIntegrator::stepB(FixedStepMemory* m, double t, double h,
   m->res[BSTEP_ADJ_V0] = nullptr;  // adj:v0
   m->res[BSTEP_ADJ_P] = adj_p;  // adj:p
   m->res[BSTEP_ADJ_U] = adj_u;  // adj:u
+  // Issue #3353: zero-init when adj_* output is structurally empty
+  const Function& adj_step = get_function(reverse_name("step", nadj_));
+  if (adj_x0 && !adj_step.nnz_out(BSTEP_ADJ_X0)) casadi_clear(adj_x0, nrx1_ * nadj_);
+  if (adj_p && !adj_step.nnz_out(BSTEP_ADJ_P)) casadi_clear(adj_p, nrq1_ * nadj_);
+  if (adj_u && !adj_step.nnz_out(BSTEP_ADJ_U)) casadi_clear(adj_u, nuq1_ * nadj_);
   calc_function(m, reverse_name("step", nadj_));
   // Evaluate sensitivities
   if (nfwd_ > 0) {
@@ -2201,6 +2206,14 @@ void FixedStepIntegrator::stepB(FixedStepMemory* m, double t, double h,
     m->res[BSTEP_ADJ_V0] = nullptr;  // fwd:adj:v0
     m->res[BSTEP_ADJ_P] = adj_p + nrq1_ * nadj_;  // fwd:adj_p
     m->res[BSTEP_ADJ_U] = adj_u + nuq1_ * nadj_;  // fwd:adj_u
+    const Function& fwd_adj_step =
+      get_function(forward_name(reverse_name("step", nadj_), nfwd_));
+    if (adj_x0 && !fwd_adj_step.nnz_out(BSTEP_ADJ_X0))
+      casadi_clear(adj_x0 + nrx1_ * nadj_, nrx1_ * nadj_ * nfwd_);
+    if (adj_p && !fwd_adj_step.nnz_out(BSTEP_ADJ_P))
+      casadi_clear(adj_p + nrq1_ * nadj_, nrq1_ * nadj_ * nfwd_);
+    if (adj_u && !fwd_adj_step.nnz_out(BSTEP_ADJ_U))
+      casadi_clear(adj_u + nuq1_ * nadj_, nuq1_ * nadj_ * nfwd_);
     calc_function(m, forward_name(reverse_name("step", nadj_), nfwd_));
   }
 }

--- a/casadi/core/integrator.cpp
+++ b/casadi/core/integrator.cpp
@@ -2070,8 +2070,10 @@ int FixedStepIntegrator::advance_noevent(IntegratorMemory* mem) const {
     }
   }
 
-  // Save algebraic variables
-  casadi_copy(m->v + nv_ - nz_, nz_, m->z);
+  // Save algebraic variables (extracted from the tail of each augmented v block)
+  for (casadi_int d = 0; d <= nfwd_; ++d) {
+    casadi_copy(m->v + (d + 1) * nv1_ - nz1_, nz1_, m->z + d * nz1_);
+  }
 
   return 0;
 }
@@ -2245,8 +2247,14 @@ void FixedStepIntegrator::impulseB(IntegratorMemory* mem,
   // Add impulse to state
   casadi_axpy(nrx_, 1., adj_x, m->adj_x);
 
-  // Add impulse to backwards dependent variables
-  casadi_axpy(nrz_, 1., adj_z, m->rv + nrv_ - nrz_);
+  // Add impulse to backwards dependent variables (one slot at the tail of each
+  // augmented block of m->rv; mirrors the algebraic-state extraction in
+  // advance_noevent)
+  casadi_int nrz_per_block = nrz1_ * nadj_;
+  for (casadi_int d = 0; d <= nfwd_; ++d) {
+    casadi_axpy(nrz_per_block, 1., adj_z + d * nrz_per_block,
+                m->rv + (d + 1) * nrv1_ - nrz_per_block);
+  }
 }
 
 ImplicitFixedStepIntegrator::ImplicitFixedStepIntegrator(

--- a/casadi/interfaces/sundials/sundials_interface.cpp
+++ b/casadi/interfaces/sundials/sundials_interface.cpp
@@ -611,6 +611,10 @@ int SundialsInterface::calc_daeB(SundialsMemory* m, double t, const double* x, c
   m->arg[BDYN_ADJ_ZERO] = nullptr;  // adj_zero
   m->res[BDAE_ADJ_X] = adj_x;  // adj_x
   m->res[BDAE_ADJ_Z] = adj_z;  // adj_z
+  // Issue #3353: zero-init when adj_* output is structurally empty
+  const Function& daeB = get_function("daeB");
+  if (adj_x && !daeB.nnz_out(BDAE_ADJ_X)) casadi_clear(adj_x, nrx1_ * nadj_);
+  if (adj_z && !daeB.nnz_out(BDAE_ADJ_Z)) casadi_clear(adj_z, nrz1_ * nadj_);
   if (calc_function(m, "daeB")) return 1;
   // Evaluate sensitivities
   if (nfwd_ > 0) {
@@ -634,6 +638,11 @@ int SundialsInterface::calc_daeB(SundialsMemory* m, double t, const double* x, c
     m->arg[BDYN_NUM_IN + BDAE_NUM_OUT + BDYN_ADJ_ZERO] = nullptr;  // fwd:adj_zero
     m->res[BDAE_ADJ_X] = adj_x ? adj_x + nrx1_ * nadj_ : 0;  // fwd:adj_x
     m->res[BDAE_ADJ_Z] = adj_z ? adj_z + nrz1_ * nadj_ : 0;  // fwd:adj_z
+    const Function& fwd_daeB = get_function(forward_name("daeB", nfwd_));
+    if (adj_x && !fwd_daeB.nnz_out(BDAE_ADJ_X))
+      casadi_clear(adj_x + nrx1_ * nadj_, nrx1_ * nadj_ * nfwd_);
+    if (adj_z && !fwd_daeB.nnz_out(BDAE_ADJ_Z))
+      casadi_clear(adj_z + nrz1_ * nadj_, nrz1_ * nadj_ * nfwd_);
     if (calc_function(m, forward_name("daeB", nfwd_))) return 1;
   }
   return 0;
@@ -680,6 +689,10 @@ int SundialsInterface::calc_quadB(SundialsMemory* m, double t, const double* x, 
   m->arg[BDYN_ADJ_ZERO] = nullptr;  // adj_zero
   m->res[BQUAD_ADJ_P] = adj_p;  // adj_p
   m->res[BQUAD_ADJ_U] = adj_u;  // adj_u
+  // Issue #3353: zero-init when adj_* output is structurally empty
+  const Function& quadB = get_function("quadB");
+  if (adj_p && !quadB.nnz_out(BQUAD_ADJ_P)) casadi_clear(adj_p, nrq1_ * nadj_);
+  if (adj_u && !quadB.nnz_out(BQUAD_ADJ_U)) casadi_clear(adj_u, nuq1_ * nadj_);
   if (calc_function(m, "quadB")) return 1;
   // Evaluate sensitivities
   if (nfwd_ > 0) {
@@ -702,6 +715,11 @@ int SundialsInterface::calc_quadB(SundialsMemory* m, double t, const double* x, 
     m->arg[BDYN_NUM_IN + BQUAD_NUM_OUT + BDYN_ADJ_ZERO] = nullptr;  // fwd:adj_zero
     m->res[BQUAD_ADJ_P] = adj_p + nrq1_ * nadj_;  // fwd:adj_p
     m->res[BQUAD_ADJ_U] = adj_u + nuq1_ * nadj_;  // fwd:adj_u
+    const Function& fwd_quadB = get_function(forward_name("quadB", nfwd_));
+    if (adj_p && !fwd_quadB.nnz_out(BQUAD_ADJ_P))
+      casadi_clear(adj_p + nrq1_ * nadj_, nrq1_ * nadj_ * nfwd_);
+    if (adj_u && !fwd_quadB.nnz_out(BQUAD_ADJ_U))
+      casadi_clear(adj_u + nuq1_ * nadj_, nuq1_ * nadj_ * nfwd_);
     if (calc_function(m, forward_name("quadB", nfwd_))) return 1;
   }
   return 0;

--- a/test/python/integration.py
+++ b/test/python/integration.py
@@ -443,7 +443,7 @@ class Integrationtests(casadiTestCase):
     for Integrator, features, options in integrators:
       self.message(Integrator)
       
-      if str(Integrator) in ["cvodes","idas","collocation"]: continue
+      if str(Integrator) in ["cvodes","idas"]: continue
       
       x = MX.sym("x")
       p = MX.sym("p")

--- a/test/python/integration.py
+++ b/test/python/integration.py
@@ -1503,7 +1503,94 @@ class Integrationtests(casadiTestCase):
     integrator = casadi.integrator("integrator", "cvodes", dae, 0, 0.1, {"expand":True, "postpone_expand":True})
     integrator(x0=1)
     self.assertTrue(integrator.get_function('jacF').is_a("SXFunction"))
-    self.checkarray(integrator.get_function('jacF')(x=1)["jac_ode_x"],1) 
-       
+    self.checkarray(integrator.get_function('jacF')(x=1)["jac_ode_x"],1)
+
+  def test_issue3371(self):
+    # Regression test for https://github.com/casadi/casadi/issues/3371
+    # FixedStepIntegrator::advance_noevent / impulseB used the trailing nz_
+    # entries of the augmented v / rv vectors, which lands inside a single
+    # forward-seed block. The result was that fwd_zf (forward) and the
+    # forward sensitivities of the adjoint outputs (forward-of-reverse)
+    # were wrong for batched forward(N>1) calls.
+    X = MX.sym("x", 2)
+    U = MX.sym("u")
+    Z = MX.sym("z")
+    dae = {"x": X, "p": U, "z": Z,
+           "ode": vertcat(Z * X[0] - X[1] + U, X[0]),
+           "alg": Z - (1 - X[1]**2)}
+
+    def cross_check(I, base_inputs, fwd_seeds_per_seed, msg):
+      """Check batched forward(N) matches N independent forward(1) calls."""
+      N = len(fwd_seeds_per_seed)
+      I1 = I.forward(1)
+      IN = I.forward(N)
+      fwd_names = [n for n in IN.name_in() if n.startswith("fwd_")]
+      # Build batched inputs by horzcat'ing per-seed entries
+      batched_seeds = {}
+      for n in fwd_names:
+        cols = []
+        for s in fwd_seeds_per_seed:
+          v = s.get(n, DM.zeros(I1.sparsity_in(n)))
+          cols.append(v)
+        batched_seeds[n] = horzcat(*cols)
+      batched = IN.call({**base_inputs, **batched_seeds})
+      per_seed = {}
+      for s in fwd_seeds_per_seed:
+        single = {n: s.get(n, DM.zeros(I1.sparsity_in(n))) for n in fwd_names}
+        out = I1.call({**base_inputs, **single})
+        for k, v in out.items():
+          per_seed.setdefault(k, []).append(v)
+      for k, b in batched.items():
+        merged = horzcat(*per_seed[k])
+        self.checkarray(b, merged, msg + " :: " + k)
+
+    # --- Forward sensitivity: trips line 2074 (advance_noevent) ---
+    I = integrator("I", "collocation", dae)
+    base = {"x0": DM([0.5, 0.0]), "z0": DM([1.0]), "p": DM([0.1]),
+            "u": DM(0, 1)}
+    base["out_xf"], base["out_zf"], base["out_qf"] = (
+      I(x0=base["x0"], z0=base["z0"], p=base["p"])[k]
+      for k in ("xf", "zf", "qf"))
+    seeds = [
+      {"fwd_x0": DM([1.0, 0.0])},
+      {"fwd_x0": DM([0.0, 1.0])},
+      {"fwd_p": DM([1.0])},
+    ]
+    cross_check(I, base, seeds, "fwd-of-collocation")
+
+    # Pin the smaller reproducer from issue #3371 (comment 1): with x0 = p = 0
+    # the trajectory stays at x=0, z=1, so fwd_zf is zero for both seeds.
+    base0 = {"x0": DM.zeros(2), "z0": DM([1.0]), "p": DM([0.0]),
+             "u": DM(0, 1),
+             "out_xf": DM.zeros(2, 1), "out_zf": DM([1.0]),
+             "out_qf": DM(0, 1)}
+    I2 = I.forward(2)
+    out = I2.call({**base0,
+                   "fwd_x0": DM([[0, 1], [0, 0]]),
+                   "fwd_z0": DM.zeros(I2.sparsity_in("fwd_z0")),
+                   "fwd_p":  DM([1, 0]).T,
+                   "fwd_u":  DM.zeros(I2.sparsity_in("fwd_u"))})
+    self.checkarray(out["fwd_zf"], DM.zeros(1, 2), "issue3371 fwd_zf")
+
+    # --- Adjoint sensitivity: trips line 2251 (impulseB) ---
+    # Forward-of-reverse: the augmented integrator has nfwd_>0 AND nadj_>0.
+    Iadj = integrator("I", "collocation", dae, {"nadj": 1})
+    ref = Iadj(x0=DM([0.5, 0.0]), z0=DM([1.0]), p=DM([0.1]),
+               adj_xf=DM([0.0, 0.0]), adj_zf=DM([1.0]),
+               adj_qf=DM(0, 1))
+    base = {"x0": DM([0.5, 0.0]), "z0": DM([1.0]), "p": DM([0.1]),
+            "u": DM(0, 1),
+            "adj_xf": DM([0.0, 0.0]), "adj_zf": DM([1.0]),
+            "adj_qf": DM(0, 1),
+            "out_xf": ref["xf"], "out_zf": ref["zf"], "out_qf": ref["qf"],
+            "out_adj_x0": ref["adj_x0"], "out_adj_z0": ref["adj_z0"],
+            "out_adj_p": ref["adj_p"], "out_adj_u": ref["adj_u"]}
+    seeds = [
+      {"fwd_adj_zf": DM([1.0])},
+      {"fwd_x0": DM([1.0, 0.0])},
+      {"fwd_p": DM([1.0])},
+    ]
+    cross_check(Iadj, base, seeds, "fwd-of-reverse-of-collocation")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
FixedStepIntegrator extracted/applied algebraic-state values using the
trailing nz_/nrz_ entries of the augmented v / rv vectors, landing inside
a single forward-seed block. They must instead be read from (resp.
impulses added to) the tail of every augmented block, since m->v / m->rv
are laid out as (1+nfwd_) blocks of nv1_ / nrv1_ entries each.

Two call sites were broken:
- advance_noevent: fwd_zf wrong for batched forward(N>1) on
  collocation/rk integrators (the bug reported in #3371).
- impulseB: forward sensitivities of adjoint outputs wrong whenever
  nfwd_>0 and nadj_>0 simultaneously.

Behaviour for nfwd_==0 is unchanged. Adds test_issue3371 in
test/python/integration.py covering both cases.