### PR TITLE
Add CONOPT NLP Solver interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1079,6 +1079,10 @@ set(BUILD_ALPAQA_VERSION "develop" CACHE STRING "Tag/branch/hash to be used for 
 option(WITH_BUILD_ALPAQA "Build Alpaqa (BUILD_ALPAQA_VERSION=${BUILD_ALPAQA_VERSION}) from downloaded source (BUILD_ALPAQA_GIT_REPO=${BUILD_ALPAQA_GIT_REPO})." OFF)
 set(BUILD_ALPAQA_DEPENDENCIES EIGEN3)
 
+# CONOPT: An NLP solver
+option(WITH_CONOPT "Compile the interface to CONOPT" OFF)
+option(WITH_MOCKUP_CONOPT "Use mockup CONOPT (BUILD_MOCKUPS_VERSION=${BUILD_MOCKUPS_VERSION}) from downloaded source (BUILD_MOCKUPS_GIT_REPO=${BUILD_MOCKUPS_GIT_REPO})." OFF)
+
 option(ALLOW_DOCKER "System has docker installed" OFF)
 
 option(WITH_ZLIB "Compile the ZLIB interface" OFF)
@@ -1223,7 +1227,7 @@ endmacro()
 
 set(WITH_BUILD_MOCKUPS OFF)
 # Packages must be sorted from high to low in the dependency graph
-foreach(PKG CPLEX SNOPT KNITRO GUROBI XPRESS MOSEK WORHP HSL MADNLP)
+foreach(PKG CPLEX SNOPT KNITRO GUROBI XPRESS MOSEK WORHP HSL MADNLP CONOPT)
   string(TOLOWER ${PKG} PKG_LOWER)
   if(WITH_${PKG} AND NOT WITH_BUILD_${PKG})
     if(NOT WITH_MOCKUP_${PKG})
@@ -3060,6 +3064,17 @@ if(WITH_SELFCONTAINED)
   install(FILES "${PROJECT_SOURCE_DIR}/LICENSE.txt" DESTINATION "${INCLUDE_PREFIX}/licenses/casadi/LICENSE")
 endif()
 
+if(WITH_CONOPT AND WITH_MOCKUP_CONOPT)
+  add_library(conopt::conopt SHARED IMPORTED)
+  add_dependencies(conopt::conopt mockups-external)
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/external_projects/mockups/conopt/include")
+  set_target_properties(conopt::conopt PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/external_projects/mockups/conopt/include"
+    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/external_projects/mockups/conopt/${SHARED_LIBRARY_RELDIR}/${CMAKE_SHARED_LIBRARY_PREFIX_SHORT}conopt${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    IMPORTED_IMPLIB "${CMAKE_BINARY_DIR}/external_projects/mockups/conopt/lib/${CMAKE_SHARED_LIBRARY_PREFIX_SHORT}conopt${CMAKE_IMPORT_LIBRARY_SUFFIX}"
+  )
+endif()
+add_feature_info(conopt-interface WITH_CONOPT "Interface to the NLP solver CONOPT.")
 
 ######################################################
 ##################### paths ##########################

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,10 @@ configuration:
 - Debug
 - Release
 
+install:
+  - choco upgrade cmake -y --no-progress --version=3.16.5
+  - set PATH=C:\Program Files\CMake\bin;%PATH%
+
 build_script:
   - set arch= Win64
   - set bitness=64

--- a/casadi/interfaces/CMakeLists.txt
+++ b/casadi/interfaces/CMakeLists.txt
@@ -35,6 +35,10 @@ if(WITH_KNITRO)
   add_subdirectory(knitro)
 endif()
 
+if(WITH_CONOPT)
+  add_subdirectory(conopt)
+endif()
+
 if(WITH_CPLEX)
   add_subdirectory(cplex)
 endif()

--- a/casadi/interfaces/conopt/CMakeLists.txt
+++ b/casadi/interfaces/conopt/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.16.3)
 casadi_plugin(Nlpsol conopt
   conopt_interface.hpp
   conopt_interface.cpp
+  conopt_interface_meta.cpp
 )
 
 casadi_plugin_link_libraries(Nlpsol conopt conopt::conopt)

--- a/casadi/interfaces/conopt/CMakeLists.txt
+++ b/casadi/interfaces/conopt/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.16.3)
+
+casadi_plugin(Nlpsol conopt
+  conopt_interface.hpp
+  conopt_interface.cpp
+)
+
+casadi_plugin_link_libraries(Nlpsol conopt conopt::conopt)

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -259,7 +259,8 @@ namespace casadi {
         // Explictly catch C API options defined in conopt.h
         if (op.first == "itlim") COIDEF_ItLim(m->cntvect, op.second.to_int());
         else if (op.first == "errlim") COIDEF_ErrLim(m->cntvect, op.second.to_int());
-        else if (op.first == "reslim") COIDEF_ResLim(m->cntvect, op.second.to_double());
+        else if (op.first == "reslim" || op.first == "timelim")
+            COIDEF_ResLim(m->cntvect, op.second.to_double());
         else if (op.first == "maxheap") COIDEF_MaxHeap(m->cntvect, op.second.to_double());
         else if (op.second.is_string()) {
             casadi_warning("CONOPT option '" + op.first + "' is a string; string options cannot be "

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -49,8 +49,6 @@ namespace casadi {
       else if (op.first == "debug") debug_ = op.second.to_bool();
     }
 
-    create_function("nlp_f", {"x", "p"}, {"f"});
-    create_function("nlp_g", {"x", "p"}, {"g"});
     Function gradf_fcn = create_function("nlp_grad_f", {"x", "p"}, {"f", "grad:f:x"});
     gradf_sp_ = gradf_fcn.sparsity_out(1);
 
@@ -235,8 +233,10 @@ namespace casadi {
     m->conopt_to_casadi.reserve(initial_row_reserve);
     m->conopt_type.reserve(initial_row_reserve);
     m->conopt_rhs.reserve(initial_row_reserve);
-    if (has_linear_jac_)
+    if (has_linear_jac_) {
       m->const_jac_vals.resize(jacg_sp_.nnz(), 0.0);
+      m->linear_at_x0.resize(ng_, 0.0);
+    }
     if (has_linear_gradf_)
       m->gradf_const_vals.resize(gradf_sp_.nnz(), 0.0);
 
@@ -406,18 +406,18 @@ namespace casadi {
       const casadi_int* g_row_c    = jacg_sp_.row();
 
       // Accumulate the linear part of G at x0 per row: sum_j a_j * x0_j
-      std::vector<double> linear_at_x0(ng_, 0.0);
+      std::fill(m->linear_at_x0.begin(), m->linear_at_x0.end(), 0.0);
       for (int c = 0; c < nx_; ++c) {
         for (casadi_int el = g_colind_c[c]; el < g_colind_c[c + 1]; ++el) {
           if (jacg_nlflag_[el] == 0)
-            linear_at_x0[g_row_c[el]] += m->const_jac_vals[el] * m->d_nlp.z[c];
+            m->linear_at_x0[g_row_c[el]] += m->const_jac_vals[el] * m->d_nlp.z[c];
         }
       }
 
       for (int ci = 0; ci < ng_; ++ci) {
         // Only adjust fully linear rows (no nonlinear Jacobian entries)
         if (jacg_rowstart_[ci + 1] != jacg_rowstart_[ci]) continue;
-        double constant = m->cached_g[ci] - linear_at_x0[ci];
+        double constant = m->cached_g[ci] - m->linear_at_x0[ci];
         if (std::abs(constant) < 1e-14) continue;
         int lb_row = m->casadi_to_conopt_lb_row[ci];
         m->conopt_rhs[lb_row - 1] -= constant;
@@ -734,6 +734,10 @@ namespace casadi {
     }
     COLSTA[NUMVAR] = nz;
 
+    casadi_assert(nz == NUMNZ,
+                   "cb_read_matrix: nz != NUMNZ - Jacobian nonzero count mismatch "
+                   "between solve()'s numnz computation and this callback's writes");
+
     return 0;
   }
 
@@ -880,7 +884,9 @@ namespace casadi {
   int COI_CALLCONV ConoptInterface::cb_2dlagrsize(int* NODRV, int NUMVAR, int NUMCON, int* NHESS, int MAXHESS, void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
-    *NHESS = self.hesslag_sp_.nnz();
+    casadi_int nhess = self.hesslag_sp_.nnz();
+    casadi_assert(nhess <= std::numeric_limits<int>::max(), "hesslag_sp_ nnz overflows int");
+    *NHESS = (int)nhess;
     if (*NHESS > MAXHESS) {
         *NODRV = 1;
     }

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -631,8 +631,8 @@ namespace casadi {
       if (!std::isinf(lb)) LOWER[i] = lb;
       if (!std::isinf(ub)) UPPER[i] = ub;
       double x0 = m->d_nlp.z[i];
-      if (!std::isinf(lb)) x0 = std::max(x0, lb);
       if (!std::isinf(ub)) x0 = std::min(x0, ub);
+      if (!std::isinf(lb)) x0 = std::max(x0, lb);
       CURR[i] = x0;
     }
 
@@ -645,9 +645,6 @@ namespace casadi {
     }
 
     if (self.warm_start_) {
-      // Always zero-initialise so that skipping the fill below is safe.
-      std::fill(VSTA, VSTA + NUMVAR, static_cast<int>(ConoptBasisStatus::AtLower));
-      std::fill(ESTA, ESTA + NUMCON, static_cast<int>(ConoptBasisStatus::AtLower));
       ESTA[0] = static_cast<int>(ConoptBasisStatus::SuperBasic);  // objective row always superbasic
 
       const double* lam = m->d_nlp.lam;

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -186,7 +186,8 @@ namespace casadi {
   }
 
   ConoptMemory::ConoptMemory(const ConoptInterface& interface)
-      : self(interface), NlpsolMemory(), cntvect(nullptr), modsta(0), solsta(0),
+      : self(interface), NlpsolMemory(), cntvect(nullptr),
+        modsta(ConoptModelStatus::Unset), solsta(ConoptSolverStatus::Unset),
         iter(0), return_status("Unset"),
         cache_valid(false), nan_encountered(false),
         ng_expanded(0), numnz_expanded(0) {}
@@ -372,17 +373,22 @@ namespace casadi {
     }
 
     m->success = !m->nan_encountered &&
-                 (m->modsta == 1 || m->modsta == 2) && m->solsta == 1;
+                 (m->modsta == ConoptModelStatus::Optimal ||
+                  m->modsta == ConoptModelStatus::LocallyOptimal) &&
+                 m->solsta == ConoptSolverStatus::NormalCompletion;
 
-    if (m->nan_encountered || m->solsta == 5) {
+    if (m->nan_encountered || m->solsta == ConoptSolverStatus::EvalErrorLimit) {
       m->unified_return_status = SOLVER_RET_NAN;
     } else if (m->success) {
       m->unified_return_status = SOLVER_RET_SUCCESS;
     } else {
-      if (m->solsta == 2 || m->solsta == 3 ||
-          m->solsta == 8 || m->solsta == 15) {
+      if (m->solsta == ConoptSolverStatus::IterationLimit ||
+          m->solsta == ConoptSolverStatus::TimeLimit ||
+          m->solsta == ConoptSolverStatus::UserInterrupt ||
+          m->solsta == ConoptSolverStatus::QuickModeTermination) {
         m->unified_return_status = SOLVER_RET_LIMITED;
-      } else if (m->modsta == 4 || m->modsta == 5) {
+      } else if (m->modsta == ConoptModelStatus::Infeasible ||
+                 m->modsta == ConoptModelStatus::LocallyInfeasible) {
         m->unified_return_status = SOLVER_RET_INFEASIBLE;
       }
     }
@@ -393,8 +399,8 @@ namespace casadi {
     Dict stats = Nlpsol::get_stats(mem);
     auto m = static_cast<ConoptMemory*>(mem);
     stats["return_status"] = m->return_status;
-    stats["modsta"] = m->modsta;
-    stats["solsta"] = m->solsta;
+    stats["modsta"] = static_cast<int>(m->modsta);
+    stats["solsta"] = static_cast<int>(m->solsta);
     stats["iter_count"] = m->iter;
     return stats;
   }
@@ -637,39 +643,39 @@ namespace casadi {
 
   int COI_CALLCONV ConoptInterface::cb_status(int MODSTA, int SOLSTA, int ITER, double OBJVAL, void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
-    m->modsta = MODSTA;
-    m->solsta = SOLSTA;
+    m->modsta = static_cast<ConoptModelStatus>(MODSTA);
+    m->solsta = static_cast<ConoptSolverStatus>(SOLSTA);
     m->iter = ITER;
     m->d_nlp.objective = OBJVAL;
 
     const char* modsta_str;
-    switch (MODSTA) {
-      case 1:  modsta_str = "Optimal";                  break;
-      case 2:  modsta_str = "Locally optimal";          break;
-      case 3:  modsta_str = "Unbounded";                break;
-      case 4:  modsta_str = "Infeasible";               break;
-      case 5:  modsta_str = "Locally infeasible";       break;
-      case 6:  modsta_str = "Intermediate infeasible";  break;
-      case 7:  modsta_str = "Intermediate non-optimal"; break;
-      case 12: modsta_str = "Unknown error";            break;
-      case 13: modsta_str = "Error: no solution";       break;
-      default: modsta_str = "Unknown model status";     break;
+    switch (m->modsta) {
+      case ConoptModelStatus::Optimal:            modsta_str = "Optimal";                  break;
+      case ConoptModelStatus::LocallyOptimal:     modsta_str = "Locally optimal";          break;
+      case ConoptModelStatus::Unbounded:          modsta_str = "Unbounded";                break;
+      case ConoptModelStatus::Infeasible:         modsta_str = "Infeasible";               break;
+      case ConoptModelStatus::LocallyInfeasible:  modsta_str = "Locally infeasible";       break;
+      case ConoptModelStatus::IntermediateInfeas: modsta_str = "Intermediate infeasible";  break;
+      case ConoptModelStatus::IntermediateNonOpt: modsta_str = "Intermediate non-optimal"; break;
+      case ConoptModelStatus::UnknownError:       modsta_str = "Unknown error";            break;
+      case ConoptModelStatus::ErrorNoSolution:    modsta_str = "Error: no solution";       break;
+      default:                                    modsta_str = "Unknown model status";     break;
     }
 
     const char* solsta_str;
-    switch (SOLSTA) {
-      case 1:  solsta_str = "Normal completion";                   break;
-      case 2:  solsta_str = "Iteration limit";                     break;
-      case 3:  solsta_str = "Time limit";                          break;
-      case 4:  solsta_str = "Terminated by solver";                break;
-      case 5:  solsta_str = "Evaluation error limit";              break;
-      case 8:  solsta_str = "User interrupt";                      break;
-      case 9:  solsta_str = "Setup failure";                       break;
-      case 10: solsta_str = "Major solver error";                  break;
-      case 11: solsta_str = "Major solver error (feasible point)"; break;
-      case 13: solsta_str = "System error";                        break;
-      case 15: solsta_str = "Quick Mode termination";              break;
-      default: solsta_str = "Unknown solver status";               break;
+    switch (m->solsta) {
+      case ConoptSolverStatus::NormalCompletion:     solsta_str = "Normal completion";                   break;
+      case ConoptSolverStatus::IterationLimit:       solsta_str = "Iteration limit";                     break;
+      case ConoptSolverStatus::TimeLimit:            solsta_str = "Time limit";                          break;
+      case ConoptSolverStatus::TerminatedBySolver:   solsta_str = "Terminated by solver";                break;
+      case ConoptSolverStatus::EvalErrorLimit:       solsta_str = "Evaluation error limit";              break;
+      case ConoptSolverStatus::UserInterrupt:        solsta_str = "User interrupt";                      break;
+      case ConoptSolverStatus::SetupFailure:         solsta_str = "Setup failure";                       break;
+      case ConoptSolverStatus::MajorSolverError:     solsta_str = "Major solver error";                  break;
+      case ConoptSolverStatus::MajorSolverErrorFeas: solsta_str = "Major solver error (feasible point)"; break;
+      case ConoptSolverStatus::SystemError:          solsta_str = "System error";                        break;
+      case ConoptSolverStatus::QuickModeTermination: solsta_str = "Quick Mode termination";              break;
+      default:                                       solsta_str = "Unknown solver status";               break;
     }
 
     m->return_status = std::string(modsta_str) + " / " + std::string(solsta_str);

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -1,7 +1,6 @@
 #include "conopt_interface.hpp"
 #include "casadi/core/casadi_misc.hpp"
 #include "casadi/core/casadi_interrupt.hpp"
-#include <cassert>
 #include <cmath>
 #include <cstring>
 #include <algorithm>
@@ -287,7 +286,6 @@ namespace casadi {
 
     if (exact_hessian_ && hesslag_sp_.nnz() > 0) {
         COIDEF_NumHess(m->cntvect, hesslag_sp_.nnz());
-        COIDEF_2DLagrSize(m->cntvect, &ConoptInterface::cb_2dlagrsize);
         COIDEF_2DLagrStr(m->cntvect, &ConoptInterface::cb_2dlagrstr);
         COIDEF_2DLagrVal(m->cntvect, &ConoptInterface::cb_2dlagrval);
     }
@@ -893,18 +891,6 @@ namespace casadi {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     m->cache_valid_jac.store(false, std::memory_order_relaxed);
     m->cache_valid.store(false, std::memory_order_relaxed);
-    return 0;
-  }
-
-  int COI_CALLCONV ConoptInterface::cb_2dlagrsize(int* NODRV, int NUMVAR, int NUMCON, int* NHESS, int MAXHESS, void* USRMEM) {
-    auto m = static_cast<ConoptMemory*>(USRMEM);
-    const ConoptInterface& self = m->self;
-    casadi_int nhess = self.hesslag_sp_.nnz();
-    casadi_assert(nhess <= std::numeric_limits<int>::max(), "hesslag_sp_ nnz overflows int");
-    *NHESS = (int)nhess;
-    if (*NHESS > MAXHESS) {
-        *NODRV = 1;
-    }
     return 0;
   }
 

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -457,6 +457,11 @@ namespace casadi {
       if (!has_nl_gradf && (gradf_sp_.nnz() == 0 || all_const_zero)) {
         m->obj_const_ = m->cached_f;
         COIDEF_OptDir(m->cntvect, 0);
+      } else {
+        // cntvect persists across solves, so explicitly reset OptDir in case a
+        // prior solve on this instance (e.g. with different parameters) hit the
+        // constant-objective branch above and left it at 0.
+        COIDEF_OptDir(m->cntvect, -1);
       }
     }
 

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -7,7 +7,7 @@
 
 namespace casadi {
 
-  extern "C" int casadi_register_nlpsol_conopt(Nlpsol::Plugin* plugin) {
+  extern "C" int CASADI_NLPSOL_CONOPT_EXPORT casadi_register_nlpsol_conopt(Nlpsol::Plugin* plugin) {
     plugin->creator = ConoptInterface::creator;
     plugin->name = "conopt";
     plugin->doc = "CONOPT Interface";
@@ -17,7 +17,7 @@ namespace casadi {
     return 0;
   }
 
-  extern "C" void casadi_load_nlpsol_conopt() {
+  extern "C" void CASADI_NLPSOL_CONOPT_EXPORT casadi_load_nlpsol_conopt() {
     Nlpsol::registerPlugin(casadi_register_nlpsol_conopt);
   }
 
@@ -74,28 +74,40 @@ namespace casadi {
     // Per-column objective-gradient flag (used in cb_read_matrix)
     const casadi_int* f_row = gradf_sp_.row();
     gradf_col_flag_.assign(nx_, false);
-    for (casadi_int k = 0; k < gradf_sp_.nnz(); ++k)
+    gradf_col_to_nz_.assign(nx_, -1);
+    for (casadi_int k = 0; k < gradf_sp_.nnz(); ++k) {
       gradf_col_flag_[f_row[k]] = true;
+      gradf_col_to_nz_[f_row[k]] = k;
+    }
+
+    // Detect constant (linear) objective gradient entries using second-order sparsity
+    {
+      Sparsity dgradf_dx = gradf_fcn.sparsity_jac(0, 1, true);
+      gradf_nlflag_.assign(gradf_sp_.nnz(), 0);
+      const casadi_int* dg_row = dgradf_dx.row();
+      for (casadi_int el = 0; el < dgradf_dx.nnz(); ++el)
+        gradf_nlflag_[dg_row[el]] = 1;
+      has_linear_gradf_ = std::any_of(gradf_nlflag_.begin(), gradf_nlflag_.end(),
+                                       [](int f) { return f == 0; });
+    }
 
     const casadi_int* g_colind = jacg_sp_.colind();
     const casadi_int* g_row = jacg_sp_.row();
 
-    // Build row-indexed (CSR) structure for fast Jacobian scatter in cb_fd_eval
+    // Build row-indexed structure over nonlinear entries only (aligns with CONOPT's JACNUM)
     casadi_int nnz_g = jacg_sp_.nnz();
     jacg_rowstart_.assign(ng_ + 1, 0);
-    jacg_col_.resize(nnz_g);
-    jacg_nzidx_.resize(nnz_g);
     for (casadi_int el = 0; el < nnz_g; ++el)
-      jacg_rowstart_[g_row[el] + 1]++;
+      if (jacg_nlflag_[el]) jacg_rowstart_[g_row[el] + 1]++;
     for (int r = 0; r < ng_; ++r)
       jacg_rowstart_[r + 1] += jacg_rowstart_[r];
+    jacg_nzidx_.resize(jacg_rowstart_[ng_]);
     std::vector<int> fill_pos(ng_, 0);
     for (int c = 0; c < nx_; ++c) {
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
+        if (!jacg_nlflag_[el]) continue;
         int r = (int)g_row[el];
-        int p = jacg_rowstart_[r] + fill_pos[r]++;
-        jacg_col_[p] = c;
-        jacg_nzidx_[p] = (int)el;
+        jacg_nzidx_[jacg_rowstart_[r] + fill_pos[r]++] = (int)el;
       }
     }
 
@@ -114,32 +126,7 @@ namespace casadi {
     s.unpack("ConoptInterface::jacg_sp", jacg_sp_);
     s.unpack("ConoptInterface::hesslag_sp", hesslag_sp_);
 
-    // Rebuild derived arrays from the serialized sparsities
-    const casadi_int* f_row = gradf_sp_.row();
-    gradf_col_flag_.assign(nx_, false);
-    for (casadi_int k = 0; k < gradf_sp_.nnz(); ++k)
-      gradf_col_flag_[f_row[k]] = true;
-
-    const casadi_int* g_colind = jacg_sp_.colind();
-    const casadi_int* g_row = jacg_sp_.row();
-    casadi_int nnz_g = jacg_sp_.nnz();
-    jacg_rowstart_.assign(ng_ + 1, 0);
-    jacg_col_.resize(nnz_g);
-    jacg_nzidx_.resize(nnz_g);
-    for (casadi_int el = 0; el < nnz_g; ++el)
-      jacg_rowstart_[g_row[el] + 1]++;
-    for (int r = 0; r < ng_; ++r)
-      jacg_rowstart_[r + 1] += jacg_rowstart_[r];
-    std::vector<int> fill_pos(ng_, 0);
-    for (int c = 0; c < nx_; ++c)
-      for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
-        int r = (int)g_row[el];
-        int p = jacg_rowstart_[r] + fill_pos[r]++;
-        jacg_col_[p] = c;
-        jacg_nzidx_[p] = (int)el;
-      }
-
-    // Recompute linearity flags (not serialized; derived from the function)
+    // Recompute linearity flags first (needed for CSR construction below)
     {
       Sparsity djac_dx = get_function("nlp_jac_g").sparsity_jac(0, 1, true);
       jacg_nlflag_.assign(jacg_sp_.nnz(), 0);
@@ -149,6 +136,42 @@ namespace casadi {
       has_linear_jac_ = std::any_of(jacg_nlflag_.begin(), jacg_nlflag_.end(),
                                      [](int f) { return f == 0; });
     }
+
+    // Rebuild derived arrays from the serialized sparsities
+    const casadi_int* f_row = gradf_sp_.row();
+    gradf_col_flag_.assign(nx_, false);
+    gradf_col_to_nz_.assign(nx_, -1);
+    for (casadi_int k = 0; k < gradf_sp_.nnz(); ++k) {
+      gradf_col_flag_[f_row[k]] = true;
+      gradf_col_to_nz_[f_row[k]] = k;
+    }
+
+    {
+      Sparsity dgradf_dx = get_function("nlp_grad_f").sparsity_jac(0, 1, true);
+      gradf_nlflag_.assign(gradf_sp_.nnz(), 0);
+      const casadi_int* dg_row = dgradf_dx.row();
+      for (casadi_int el = 0; el < dgradf_dx.nnz(); ++el)
+        gradf_nlflag_[dg_row[el]] = 1;
+      has_linear_gradf_ = std::any_of(gradf_nlflag_.begin(), gradf_nlflag_.end(),
+                                       [](int f) { return f == 0; });
+    }
+
+    const casadi_int* g_colind = jacg_sp_.colind();
+    const casadi_int* g_row = jacg_sp_.row();
+    casadi_int nnz_g = jacg_sp_.nnz();
+    jacg_rowstart_.assign(ng_ + 1, 0);
+    for (casadi_int el = 0; el < nnz_g; ++el)
+      if (jacg_nlflag_[el]) jacg_rowstart_[g_row[el] + 1]++;
+    for (int r = 0; r < ng_; ++r)
+      jacg_rowstart_[r + 1] += jacg_rowstart_[r];
+    jacg_nzidx_.resize(jacg_rowstart_[ng_]);
+    std::vector<int> fill_pos(ng_, 0);
+    for (int c = 0; c < nx_; ++c)
+      for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
+        if (!jacg_nlflag_[el]) continue;
+        int r = (int)g_row[el];
+        jacg_nzidx_[jacg_rowstart_[r] + fill_pos[r]++] = (int)el;
+      }
   }
 
   void ConoptInterface::serialize_body(SerializingStream &s) const {
@@ -164,8 +187,8 @@ namespace casadi {
 
   ConoptMemory::ConoptMemory(const ConoptInterface& interface)
       : self(interface), NlpsolMemory(), cntvect(nullptr), modsta(0), solsta(0),
-        iter(0), return_status("Unset"), success(0),
-        cache_valid(false), current_option_idx(0),
+        iter(0), return_status("Unset"),
+        cache_valid(false), nan_encountered(false),
         ng_expanded(0), numnz_expanded(0) {}
 
   ConoptMemory::~ConoptMemory() {
@@ -186,6 +209,8 @@ namespace casadi {
     m->casadi_to_conopt_ub_row.assign(ng_, -1);
     if (has_linear_jac_)
       m->const_jac_vals.resize(jacg_sp_.nnz(), 0.0);
+    if (has_linear_gradf_)
+      m->gradf_const_vals.resize(gradf_sp_.nnz(), 0.0);
 
     COI_Create(&m->cntvect);
 
@@ -209,7 +234,6 @@ namespace casadi {
             m->custom_options.push_back(op);
         }
     }
-    m->current_option_idx = 0;
     COIDEF_Option(m->cntvect, &ConoptInterface::cb_option);
     COIDEF_Progress(m->cntvect, &ConoptInterface::cb_progress);
 
@@ -219,12 +243,14 @@ namespace casadi {
     COIDEF_FDEval(m->cntvect, &ConoptInterface::cb_fd_eval);
     COIDEF_FDEvalEnd(m->cntvect, &ConoptInterface::cb_fdevalend);
 
-    if (exact_hessian_) {
+    if (exact_hessian_ && hesslag_sp_.nnz() > 0) {
         COIDEF_NumHess(m->cntvect, hesslag_sp_.nnz());
         COIDEF_2DLagrSize(m->cntvect, &ConoptInterface::cb_2dlagrsize);
         COIDEF_2DLagrStr(m->cntvect, &ConoptInterface::cb_2dlagrstr);
         COIDEF_2DLagrVal(m->cntvect, &ConoptInterface::cb_2dlagrval);
     }
+
+    COIDEF_FVincLin(m->cntvect, 1);
 
     COIDEF_Status(m->cntvect, &ConoptInterface::cb_status);
     COIDEF_Solution(m->cntvect, &ConoptInterface::cb_solution);
@@ -242,13 +268,21 @@ namespace casadi {
   int ConoptInterface::solve(void* mem) const {
     auto m = static_cast<ConoptMemory*>(mem);
     m->cache_valid = false;
-    m->current_option_idx = 0;
+    m->nan_encountered = false;
 
     // Build the per-solve constraint expansion (splits range constraints into two rows)
     m->conopt_to_casadi.clear();
     m->casadi_to_conopt_ub_row.assign(ng_, -1);
     m->conopt_type.clear();
     m->conopt_rhs.clear();
+
+    // Compute total nnz per CasADi row (needed for range-constraint NZ duplication)
+    std::vector<int> row_nnz(ng_, 0);
+    {
+      const casadi_int* g_row_s = jacg_sp_.row();
+      for (casadi_int el = 0; el < (casadi_int)jacg_sp_.nnz(); ++el)
+        row_nnz[g_row_s[el]]++;
+    }
 
     int ng_expanded = 0;
     // Base NZ: objective gradient columns + all constraint Jacobian entries
@@ -279,7 +313,7 @@ namespace casadi {
         m->conopt_to_casadi.push_back((int)i);
         m->conopt_type.push_back(2);  m->conopt_rhs.push_back(ubg);  // <= row
         ng_expanded++;
-        numnz += jacg_rowstart_[i + 1] - jacg_rowstart_[i];
+        numnz += row_nnz[i];
       }
     }
     m->ng_expanded    = ng_expanded;
@@ -298,10 +332,25 @@ namespace casadi {
       }
     }
 
-    // Count nonlinear NZ: all objective gradient entries + nonlinear constraint entries
+    // Evaluate objective gradient at initial point for constant entries
+    if (has_linear_gradf_) {
+      m->arg[0] = m->d_nlp.z;
+      m->arg[1] = m->d_nlp.p;
+      m->res[0] = &m->cached_f;
+      m->res[1] = m->gradf_const_vals.data();
+      try {
+        calc_function(m, "nlp_grad_f");
+      } catch (...) {
+        std::fill(m->gradf_const_vals.begin(), m->gradf_const_vals.end(), 0.0);
+      }
+    }
+
+    // Count nonlinear NZ: nonlinear objective gradient entries + nonlinear constraint entries
     const casadi_int* g_colind_s = jacg_sp_.colind();
     const casadi_int* g_row_s    = jacg_sp_.row();
-    int num_nl_nz = (int)gradf_sp_.nnz();
+    int num_nl_nz = 0;
+    for (casadi_int k = 0; k < (casadi_int)gradf_sp_.nnz(); ++k)
+      if (gradf_nlflag_[k]) num_nl_nz++;
     for (casadi_int c = 0; c < nx_; ++c) {
       for (casadi_int el = g_colind_s[c]; el < g_colind_s[c+1]; ++el) {
         if (jacg_nlflag_[el]) {
@@ -317,16 +366,20 @@ namespace casadi {
 
     int ret = COI_Solve(m->cntvect);
     if (ret != 0) {
-      // Hard error before status/solution callbacks were reached
       m->success = false;
-      m->unified_return_status = SOLVER_RET_UNKNOWN;
+      m->unified_return_status = m->nan_encountered ? SOLVER_RET_NAN : SOLVER_RET_UNKNOWN;
       return 0;
     }
 
-    m->success = (m->modsta == 1 || m->modsta == 2) && m->solsta == 1;
+    m->success = !m->nan_encountered &&
+                 (m->modsta == 1 || m->modsta == 2) && m->solsta == 1;
 
-    if (!m->success) {
-      if (m->solsta == 2 || m->solsta == 3 || m->solsta == 5 ||
+    if (m->nan_encountered || m->solsta == 5) {
+      m->unified_return_status = SOLVER_RET_NAN;
+    } else if (m->success) {
+      m->unified_return_status = SOLVER_RET_SUCCESS;
+    } else {
+      if (m->solsta == 2 || m->solsta == 3 ||
           m->solsta == 8 || m->solsta == 15) {
         m->unified_return_status = SOLVER_RET_LIMITED;
       } else if (m->modsta == 4 || m->modsta == 5) {
@@ -350,22 +403,18 @@ namespace casadi {
   int COI_CALLCONV ConoptInterface::cb_option(int NCALL, double* RVAL, int* IVAL, int* LVAL, char* NAME, void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
 
-    if (m->current_option_idx < m->custom_options.size()) {
-        auto& opt = m->custom_options[m->current_option_idx];
-
-        std::string name = opt.first;
-        if (name.length() > 8) name = name.substr(0, 8);
-        else name.append(8 - name.length(), ' ');
-        std::strncpy(NAME, name.c_str(), 8);
-
-        if (opt.second.is_double()) *RVAL = opt.second.to_double();
-        else if (opt.second.is_int()) *IVAL = opt.second.to_int();
-        else if (opt.second.is_bool()) *LVAL = opt.second.to_bool() ? 1 : 0;
-
-        m->current_option_idx++;
-    } else {
-        std::strncpy(NAME, "        ", 8);
+    if (NCALL >= (int)m->custom_options.size()) {
+        NAME[0] = '\0';
+        return 0;
     }
+
+    auto& opt = m->custom_options[NCALL];
+    std::strcpy(NAME, opt.first.c_str());
+
+    if (opt.second.is_double())     *RVAL = opt.second.to_double();
+    else if (opt.second.is_int())   *IVAL = opt.second.to_int();
+    else if (opt.second.is_bool())  *LVAL = opt.second.to_bool() ? 1 : 0;
+
     return 0;
   }
 
@@ -429,8 +478,10 @@ namespace casadi {
     for (int c = 0; c < NUMVAR; ++c) {
       COLSTA[c] = nz;
       if (self.gradf_col_flag_[c]) {
+        casadi_int k = self.gradf_col_to_nz_[c];
         ROWNO[nz]  = 0;
-        NLFLAG[nz] = 1;
+        NLFLAG[nz] = self.gradf_nlflag_[k];
+        if (self.gradf_nlflag_[k] == 0) VALUE[nz] = m->gradf_const_vals[k];
         nz++;
       }
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
@@ -472,9 +523,31 @@ namespace casadi {
         self.calc_function(m, "nlp_jac_g");
 
         m->cache_valid = true;
+    } catch (std::exception& ex) {
+        casadi::uerr() << ex.what() << std::endl;
+        *ERRCNT = 1;
+        m->nan_encountered = true;
+        m->cache_valid = false;
     } catch (...) {
         *ERRCNT = 1;
+        m->nan_encountered = true;
         m->cache_valid = false;
+    }
+
+    // Detect silent NaN from CasADi (e.g. sqrt of negative number)
+    if (m->cache_valid) {
+        bool has_nan = std::isnan(m->cached_f);
+        if (!has_nan) {
+            for (double v : m->cached_g) if (std::isnan(v)) { has_nan = true; break; }
+        }
+        if (!has_nan) {
+            for (double v : m->cached_grad_f) if (std::isnan(v)) { has_nan = true; break; }
+        }
+        if (has_nan) {
+            *ERRCNT = 1;
+            m->nan_encountered = true;
+            m->cache_valid = false;
+        }
     }
     return 0;
   }
@@ -493,18 +566,16 @@ namespace casadi {
         if (MODE == 2 || MODE == 3) {
             std::memset(JAC, 0, NUMVAR * sizeof(double));
             const casadi_int* f_row = self.gradf_sp_.row();
-            for (casadi_int k = 0; k < self.gradf_sp_.nnz(); ++k) {
+            for (casadi_int k = 0; k < self.gradf_sp_.nnz(); ++k)
                 JAC[f_row[k]] = m->cached_grad_f[k];
-            }
         }
-    }
-    else {
-        int ci = m->conopt_to_casadi[ROWNO - 1];  // CasADi constraint index
+    } else {
+        int ci = m->conopt_to_casadi[ROWNO - 1];
         if (MODE == 1 || MODE == 3) *G = m->cached_g[ci];
         if (MODE == 2 || MODE == 3) {
-            std::memset(JAC, 0, NUMVAR * sizeof(double));
-            for (int k = self.jacg_rowstart_[ci]; k < self.jacg_rowstart_[ci + 1]; ++k)
-                JAC[self.jacg_col_[k]] = m->cached_jac_g[self.jacg_nzidx_[k]];
+            int base = self.jacg_rowstart_[ci];
+            for (int k = 0; k < NUMJAC; ++k)
+                JAC[JACNUM[k]] = m->cached_jac_g[self.jacg_nzidx_[base + k]];
         }
     }
     return 0;

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -116,6 +116,8 @@ namespace casadi {
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
         if (!jacg_nlflag_[el]) continue;
         int r = (int)g_row[el];
+        casadi_assert(fill_pos[r] < jacg_rowstart_[r + 1] - jacg_rowstart_[r],
+                      "CSR fill overflow for row r - count/fill pass mismatch in jacg_rowstart_");
         int pos = jacg_rowstart_[r] + fill_pos[r]++;
         jacg_nzidx_[pos] = (int)el;
         jacg_col_[pos]   = c;
@@ -180,6 +182,8 @@ namespace casadi {
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
         if (!jacg_nlflag_[el]) continue;
         int r = (int)g_row[el];
+        casadi_assert(fill_pos[r] < jacg_rowstart_[r + 1] - jacg_rowstart_[r],
+                      "CSR fill overflow for row r - count/fill pass mismatch in jacg_rowstart_");
         int pos = jacg_rowstart_[r] + fill_pos[r]++;
         jacg_nzidx_[pos] = (int)el;
         jacg_col_[pos]   = c;
@@ -629,6 +633,12 @@ namespace casadi {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
+    // CONOPT is expected to echo back exactly what we told it via COIDEF_NumVar/
+    // COIDEF_NumCon in init_mem()/solve() — a mismatch means the interface's own
+    // bookkeeping (nx_, ng_expanded) is desynced from what CONOPT is using.
+    casadi_assert(NUMVAR == self.nx_, "cb_read_matrix: NUMVAR != nx_");
+    casadi_assert(NUMCON == m->ng_expanded + 1, "cb_read_matrix: NUMCON != ng_expanded + 1");
+
     // Variable bounds and initial point (clamped to [lb, ub])
     for (int i = 0; i < NUMVAR; ++i) {
       double lb = m->d_nlp.lbz[i];
@@ -745,6 +755,9 @@ namespace casadi {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
+    casadi_assert(NUMVAR == self.nx_, "cb_fdevalini: NUMVAR != nx_");
+    casadi_assert((size_t)NUMVAR == m->cached_x.size(), "cb_fdevalini: NUMVAR != cached_x size");
+
     std::memcpy(m->cached_x.data(), X, NUMVAR * sizeof(double));
 
     if (self.debug_) {
@@ -838,6 +851,8 @@ namespace casadi {
             }
         }
     } else {
+        casadi_assert(ROWNO >= 1 && ROWNO <= m->ng_expanded,
+                      "cb_fd_eval: ROWNO out of range");
         int ci = m->conopt_to_casadi[ROWNO - 1];
         if (MODE == 1 || MODE == 3) {
             *G = m->cached_g[ci];
@@ -907,6 +922,8 @@ namespace casadi {
             idx++;
         }
     }
+    casadi_assert(idx == NHESS,
+                  "cb_2dlagrstr: idx != NHESS - Hessian nonzero count mismatch");
     return 0;
   }
 

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -227,10 +227,11 @@ namespace casadi {
     m->casadi_to_conopt_ub_row.assign(ng_, -1);
     m->hess_lam_g_.resize(ng_, 0.0);
     m->row_nnz.assign(ng_, 0);
-    // Most problems have few or no range constraints, so reserve a fraction of
-    // the worst case (all rows range); solve() grows these
-    // vectors on demand as rows are actually expanded.
-    casadi_int initial_row_reserve = std::max<casadi_int>(1, ng_ / 4);
+    // Every CasADi row contributes at least one entry (range constraints add a
+    // second), so ng_ is a guaranteed lower bound on the final size — reserving
+    // less would force a reallocation on essentially every solve. solve() grows
+    // these vectors further on demand only for the range-constraint rows.
+    casadi_int initial_row_reserve = ng_;
     m->conopt_to_casadi.reserve(initial_row_reserve);
     m->conopt_type.reserve(initial_row_reserve);
     m->conopt_rhs.reserve(initial_row_reserve);

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -823,14 +823,15 @@ namespace casadi {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
-    // U[0] maps directly to obj_factor: the objective row carries no sign flip.
-    // U[row] for constraint rows uses the negation of CasADi's lam_g convention
-    // (CONOPT shadow price = -lam_g), consistent with cb_solution's lam = -ymar.
+    // CONOPT's Lagrangian: L = SUM(r) U(r) * F(r), so d²L/dx² = SUM(r) U(r) * d²F(r)/dx².
+    // CasADi computes lam_f*d²f/dx² + lam_g^T*d²g/dx², so lam_f = U[0], lam_g[ci] = U[row_ci].
+    // No sign flip: CONOPT's U is the Lagrangian weight directly, not the shadow price (YMAR).
     double obj_factor = U[0];
 
     for (int ci = 0; ci < self.ng_; ++ci) {
       int row1 = m->casadi_to_conopt_lb_row[ci];
       int row2 = m->casadi_to_conopt_ub_row[ci];
+      m->hess_lam_g_[ci] = U[row1] + (row2 >= 0 ? U[row2] : 0.0);
     }
 
     if (self.debug_) {

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstring>
 #include <algorithm>
+#include <limits>
 
 namespace casadi {
 
@@ -198,7 +199,7 @@ namespace casadi {
       : self(interface), NlpsolMemory(), cntvect(nullptr),
         modsta(ConoptModelStatus::Unset), solsta(ConoptSolverStatus::Unset),
         iter(0), return_status("Unset"),
-        cache_valid(false), nan_encountered(false),
+        cache_valid(false), cache_valid_jac(false), nan_encountered(false),
         ng_expanded(0), numnz_expanded(0) {}
 
   ConoptMemory::~ConoptMemory() {
@@ -218,12 +219,19 @@ namespace casadi {
     m->casadi_to_conopt_lb_row.resize(ng_);
     m->casadi_to_conopt_ub_row.assign(ng_, -1);
     m->hess_lam_g_.resize(ng_, 0.0);
+    m->row_nnz.assign(ng_, 0);
+    m->conopt_to_casadi.reserve(ng_ * 2);  // worst-case: all constraints are range
+    m->conopt_type.reserve(ng_ * 2);
+    m->conopt_rhs.reserve(ng_ * 2);
     if (has_linear_jac_)
       m->const_jac_vals.resize(jacg_sp_.nnz(), 0.0);
     if (has_linear_gradf_)
       m->gradf_const_vals.resize(gradf_sp_.nnz(), 0.0);
 
-    COI_Create(&m->cntvect);
+    if (COI_Create(&m->cntvect) != 0 || m->cntvect == nullptr) {
+      casadi::uerr() << "CONOPT: COI_Create failed" << std::endl;
+      return 1;
+    }
 
     if (warm_start_) COIDEF_IniStat(m->cntvect, 2);
 
@@ -247,7 +255,6 @@ namespace casadi {
                            "passed via the CONOPT option callback (no SVAL parameter). "
                            "Use the 'optfile' option instead.");
         } else {
-            // Push to custom options for the cb_option callback to feed dynamically
             m->custom_options.push_back(op);
         }
     }
@@ -285,7 +292,9 @@ namespace casadi {
 
   int ConoptInterface::solve(void* mem) const {
     auto m = static_cast<ConoptMemory*>(mem);
-    m->cache_valid = false;
+    m->cache_valid     = false;
+    m->cache_valid_jac = false;
+    m->cached_f        = 0.0;
     m->nan_encountered = false;
 
     // Build the per-solve constraint expansion (splits range constraints into two rows)
@@ -295,23 +304,23 @@ namespace casadi {
     m->conopt_rhs.clear();
 
     // Compute total nnz per CasADi row (needed for range-constraint NZ duplication)
-    std::vector<int> row_nnz(ng_, 0);
+    std::fill(m->row_nnz.begin(), m->row_nnz.end(), 0);
     {
       const casadi_int* g_row_s = jacg_sp_.row();
       for (casadi_int el = 0; el < (casadi_int)jacg_sp_.nnz(); ++el)
-        row_nnz[g_row_s[el]]++;
+        m->row_nnz[g_row_s[el]]++;
     }
 
-    int ng_expanded = 0;
+    casadi_int ng_expanded = 0;
     // Base NZ: objective gradient columns + all constraint Jacobian entries
-    int numnz = (int)gradf_sp_.nnz() + (int)jacg_sp_.nnz();
+    casadi_int numnz = (casadi_int)gradf_sp_.nnz() + (casadi_int)jacg_sp_.nnz();
 
     for (casadi_int i = 0; i < ng_; ++i) {
       double lbg = m->d_nlp.lbz[nx_ + i];
       double ubg = m->d_nlp.ubz[nx_ + i];
       bool is_range = !std::isinf(lbg) && !std::isinf(ubg) && lbg != ubg;
 
-      m->casadi_to_conopt_lb_row[i] = ng_expanded + 1;  // 1-indexed CONOPT row
+      m->casadi_to_conopt_lb_row[i] = (int)(ng_expanded + 1);  // 1-indexed CONOPT row
       m->conopt_to_casadi.push_back((int)i);
       if (lbg == ubg) {
         m->conopt_type.push_back(0);  m->conopt_rhs.push_back(lbg);
@@ -327,15 +336,17 @@ namespace casadi {
       ng_expanded++;
 
       if (is_range) {
-        m->casadi_to_conopt_ub_row[i] = ng_expanded + 1;
+        m->casadi_to_conopt_ub_row[i] = (int)(ng_expanded + 1);
         m->conopt_to_casadi.push_back((int)i);
         m->conopt_type.push_back(2);  m->conopt_rhs.push_back(ubg);  // <= row
         ng_expanded++;
-        numnz += row_nnz[i];
+        numnz += m->row_nnz[i];
       }
     }
-    m->ng_expanded    = ng_expanded;
-    m->numnz_expanded = numnz;
+    casadi_assert(ng_expanded <= std::numeric_limits<int>::max(), "ng_expanded overflows int");
+    casadi_assert(numnz       <= std::numeric_limits<int>::max(), "numnz overflows int");
+    m->ng_expanded    = (int)ng_expanded;
+    m->numnz_expanded = (int)numnz;
 
     // Evaluate Jacobian at the initial point to obtain values for constant entries
     if (has_linear_jac_) {
@@ -374,7 +385,7 @@ namespace casadi {
     // Count nonlinear NZ: nonlinear objective gradient entries + nonlinear constraint entries
     const casadi_int* g_colind_s = jacg_sp_.colind();
     const casadi_int* g_row_s    = jacg_sp_.row();
-    int num_nl_nz = 0;
+    casadi_int num_nl_nz = 0;
     for (casadi_int k = 0; k < (casadi_int)gradf_sp_.nnz(); ++k)
       if (gradf_nlflag_[k]) num_nl_nz++;
     for (casadi_int c = 0; c < nx_; ++c) {
@@ -386,9 +397,11 @@ namespace casadi {
       }
     }
 
-    COIDEF_NumCon(m->cntvect, ng_expanded + 1);
-    COIDEF_NumNz(m->cntvect, numnz);
-    COIDEF_NumNlNz(m->cntvect, num_nl_nz);
+    casadi_assert(num_nl_nz <= std::numeric_limits<int>::max(), "num_nl_nz overflows int");
+
+    COIDEF_NumCon(m->cntvect, (int)(ng_expanded + 1));
+    COIDEF_NumNz(m->cntvect, (int)numnz);
+    COIDEF_NumNlNz(m->cntvect, (int)num_nl_nz);
 
     int ret = COI_Solve(m->cntvect);
     if (ret != 0) {
@@ -476,9 +489,9 @@ namespace casadi {
     if (!self.fcallback_.is_null()) {
         int phase = (LEN_INT > 1) ? INTX[1] : -1;
 
-        double obj_val = 0.0;
+        double obj_val = m->cached_f;  // best available approximation for early phases
         if (LEN_RL > 1 && phase >= 3) {
-            obj_val = RL[1];
+            obj_val = RL[1];            // CONOPT-reported value once available
         }
 
         std::fill_n(m->arg, self.fcallback_.n_in(), nullptr);
@@ -609,6 +622,8 @@ namespace casadi {
 
     std::memcpy(m->cached_x.data(), X, NUMVAR * sizeof(double));
 
+    const bool need_jac = (MODE != 1);
+
     try {
         m->arg[0] = m->cached_x.data();
         m->arg[1] = m->d_nlp.p;
@@ -617,24 +632,30 @@ namespace casadi {
         m->res[1] = m->cached_grad_f.data();
         self.calc_function(m, "nlp_grad_f");
 
+        // When MODE==1, only function values (G) are needed — skip Jacobian computation.
         m->res[0] = m->cached_g.data();
-        m->res[1] = m->cached_jac_g.data();
+        m->res[1] = need_jac ? m->cached_jac_g.data() : nullptr;
         self.calc_function(m, "nlp_jac_g");
 
-        m->cache_valid = true;
+        // cache_valid_jac is stored before cache_valid (release).  The release on
+        // cache_valid orders both stores, so readers need only an acquire on cache_valid.
+        m->cache_valid_jac.store(need_jac, std::memory_order_relaxed);
+        m->cache_valid.store(true, std::memory_order_release);
     } catch (std::exception& ex) {
         casadi::uerr() << ex.what() << std::endl;
         *ERRCNT = 1;
         m->nan_encountered = true;
-        m->cache_valid = false;
+        m->cache_valid_jac.store(false, std::memory_order_relaxed);
+        m->cache_valid.store(false, std::memory_order_relaxed);
     } catch (...) {
         *ERRCNT = 1;
         m->nan_encountered = true;
-        m->cache_valid = false;
+        m->cache_valid_jac.store(false, std::memory_order_relaxed);
+        m->cache_valid.store(false, std::memory_order_relaxed);
     }
 
     // Detect silent NaN from CasADi (e.g. sqrt of negative number)
-    if (m->cache_valid) {
+    if (m->cache_valid.load(std::memory_order_relaxed)) {
         bool has_nan = std::isnan(m->cached_f);
         if (!has_nan) {
             for (double v : m->cached_g) if (std::isnan(v)) { has_nan = true; break; }
@@ -642,10 +663,14 @@ namespace casadi {
         if (!has_nan) {
             for (double v : m->cached_grad_f) if (std::isnan(v)) { has_nan = true; break; }
         }
+        if (!has_nan && need_jac) {
+            for (double v : m->cached_jac_g) if (std::isnan(v)) { has_nan = true; break; }
+        }
         if (has_nan) {
             *ERRCNT = 1;
             m->nan_encountered = true;
-            m->cache_valid = false;
+            m->cache_valid_jac.store(false, std::memory_order_relaxed);
+            m->cache_valid.store(false, std::memory_order_relaxed);
         }
     }
     return 0;
@@ -655,10 +680,18 @@ namespace casadi {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
-    if (!m->cache_valid) {
+    // Acquire load: establishes happens-before with the release store in cb_fdevalini,
+    // making all cache writes (including cached_jac_g and cache_valid_jac) visible here.
+    if (!m->cache_valid.load(std::memory_order_acquire)) {
         *ERRCNT = 1;
         return 0;
     }
+
+#ifndef NDEBUG
+    casadi_assert(
+      std::memcmp(X, m->cached_x.data(), NUMVAR * sizeof(double)) == 0,
+      "cb_fd_eval: X does not match cached_x — CONOPT API contract violated");
+#endif
 
     if (ROWNO == 0) {
         if (MODE == 1 || MODE == 3) *G = m->cached_f;
@@ -671,6 +704,12 @@ namespace casadi {
         int ci = m->conopt_to_casadi[ROWNO - 1];
         if (MODE == 1 || MODE == 3) *G = m->cached_g[ci];
         if (MODE == 2 || MODE == 3) {
+            // Guard against stale Jacobian: cache_valid_jac is false when cb_fdevalini
+            // was called with MODE==1 and skipped Jacobian computation.
+            if (!m->cache_valid_jac.load(std::memory_order_relaxed)) {
+                *ERRCNT = 1;
+                return 0;
+            }
             int base  = self.jacg_rowstart_[ci];
             int count = self.jacg_rowstart_[ci + 1] - self.jacg_rowstart_[ci];
             for (int k = 0; k < count; ++k)
@@ -682,7 +721,8 @@ namespace casadi {
 
   int COI_CALLCONV ConoptInterface::cb_fdevalend(int IGNERR, int* ERRCNT, void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
-    m->cache_valid = false;
+    m->cache_valid_jac.store(false, std::memory_order_relaxed);
+    m->cache_valid.store(false, std::memory_order_relaxed);
     return 0;
   }
 
@@ -717,6 +757,9 @@ namespace casadi {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
+    // U[0] maps directly to obj_factor: the objective row carries no sign flip.
+    // U[row] for constraint rows uses the negation of CasADi's lam_g convention
+    // (CONOPT shadow price = -lam_g), consistent with cb_solution's lam = -ymar.
     double obj_factor = U[0];
 
     for (int ci = 0; ci < self.ng_; ++ci) {
@@ -807,7 +850,7 @@ namespace casadi {
   }
 
   int COI_CALLCONV ConoptInterface::cb_message(int SMSG, int DMSG, int NMSG, char* MSGV[], void* USRMEM) {
-    for (int i = 0; i < SMSG; ++i) {
+    for (int i = 0; i < std::min(SMSG, NMSG); ++i) {
         if (MSGV[i] != nullptr) {
             casadi::uout() << MSGV[i] << std::endl;
         }

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -58,29 +58,33 @@ namespace casadi {
       alloc_w(hesslag_sp_.nnz(), true);
     }
 
-    jac_colsta_.resize(nx_ + 1, 0);
-    int numnz = 0;
-    std::vector<bool> has_gradf(nx_, false);
+    // Per-column objective-gradient flag (used in cb_read_matrix)
     const casadi_int* f_row = gradf_sp_.row();
-    for (casadi_int k = 0; k < gradf_sp_.nnz(); ++k) has_gradf[f_row[k]] = true;
+    gradf_col_flag_.assign(nx_, false);
+    for (casadi_int k = 0; k < gradf_sp_.nnz(); ++k)
+      gradf_col_flag_[f_row[k]] = true;
 
     const casadi_int* g_colind = jacg_sp_.colind();
     const casadi_int* g_row = jacg_sp_.row();
 
+    // Build row-indexed (CSR) structure for fast Jacobian scatter in cb_fd_eval
+    casadi_int nnz_g = jacg_sp_.nnz();
+    jacg_rowstart_.assign(ng_ + 1, 0);
+    jacg_col_.resize(nnz_g);
+    jacg_nzidx_.resize(nnz_g);
+    for (casadi_int el = 0; el < nnz_g; ++el)
+      jacg_rowstart_[g_row[el] + 1]++;
+    for (int r = 0; r < ng_; ++r)
+      jacg_rowstart_[r + 1] += jacg_rowstart_[r];
+    std::vector<int> fill_pos(ng_, 0);
     for (int c = 0; c < nx_; ++c) {
-      jac_colsta_[c] = numnz;
-      if (has_gradf[c]) {
-        jac_rowno_.push_back(0);
-        jac_nlflag_.push_back(1);
-        numnz++;
-      }
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
-        jac_rowno_.push_back(g_row[el] + 1);
-        jac_nlflag_.push_back(1);
-        numnz++;
+        int r = (int)g_row[el];
+        int p = jacg_rowstart_[r] + fill_pos[r]++;
+        jacg_col_[p] = c;
+        jacg_nzidx_[p] = (int)el;
       }
     }
-    jac_colsta_[nx_] = numnz;
 
     alloc_w(1, true);
     alloc_w(gradf_sp_.nnz(), true);
@@ -90,15 +94,37 @@ namespace casadi {
 
   // --- Serialization & Deserialization --- //
   ConoptInterface::ConoptInterface(DeserializingStream& s) : Nlpsol(s) {
-    int version = s.version("ConoptInterface", 1);
+    s.version("ConoptInterface", 1);
     s.unpack("ConoptInterface::exact_hessian", exact_hessian_);
     s.unpack("ConoptInterface::opts", opts_);
     s.unpack("ConoptInterface::gradf_sp", gradf_sp_);
     s.unpack("ConoptInterface::jacg_sp", jacg_sp_);
     s.unpack("ConoptInterface::hesslag_sp", hesslag_sp_);
-    s.unpack("ConoptInterface::jac_colsta", jac_colsta_);
-    s.unpack("ConoptInterface::jac_rowno", jac_rowno_);
-    s.unpack("ConoptInterface::jac_nlflag", jac_nlflag_);
+
+    // Rebuild derived arrays from the serialized sparsities
+    const casadi_int* f_row = gradf_sp_.row();
+    gradf_col_flag_.assign(nx_, false);
+    for (casadi_int k = 0; k < gradf_sp_.nnz(); ++k)
+      gradf_col_flag_[f_row[k]] = true;
+
+    const casadi_int* g_colind = jacg_sp_.colind();
+    const casadi_int* g_row = jacg_sp_.row();
+    casadi_int nnz_g = jacg_sp_.nnz();
+    jacg_rowstart_.assign(ng_ + 1, 0);
+    jacg_col_.resize(nnz_g);
+    jacg_nzidx_.resize(nnz_g);
+    for (casadi_int el = 0; el < nnz_g; ++el)
+      jacg_rowstart_[g_row[el] + 1]++;
+    for (int r = 0; r < ng_; ++r)
+      jacg_rowstart_[r + 1] += jacg_rowstart_[r];
+    std::vector<int> fill_pos(ng_, 0);
+    for (int c = 0; c < nx_; ++c)
+      for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
+        int r = (int)g_row[el];
+        int p = jacg_rowstart_[r] + fill_pos[r]++;
+        jacg_col_[p] = c;
+        jacg_nzidx_[p] = (int)el;
+      }
   }
 
   void ConoptInterface::serialize_body(SerializingStream &s) const {
@@ -109,14 +135,14 @@ namespace casadi {
     s.pack("ConoptInterface::gradf_sp", gradf_sp_);
     s.pack("ConoptInterface::jacg_sp", jacg_sp_);
     s.pack("ConoptInterface::hesslag_sp", hesslag_sp_);
-    s.pack("ConoptInterface::jac_colsta", jac_colsta_);
-    s.pack("ConoptInterface::jac_rowno", jac_rowno_);
-    s.pack("ConoptInterface::jac_nlflag", jac_nlflag_);
+    // Derived arrays (gradf_col_flag_, CSR) are rebuilt on deserialization
   }
 
   ConoptMemory::ConoptMemory(const ConoptInterface& interface)
       : self(interface), NlpsolMemory(), cntvect(nullptr), modsta(0), solsta(0),
-        iter(0), return_status("Unset"), success(0), cache_valid(false), current_option_idx(0) {}
+        iter(0), return_status("Unset"), success(0),
+        cache_valid(false), current_option_idx(0),
+        ng_expanded(0), numnz_expanded(0) {}
 
   ConoptMemory::~ConoptMemory() {
     if (cntvect) COI_Free(&cntvect);
@@ -132,15 +158,17 @@ namespace casadi {
     m->cached_grad_f.resize(gradf_sp_.nnz(), 0.0);
     m->cached_g.resize(ng_, 0.0);
     m->cached_jac_g.resize(jacg_sp_.nnz(), 0.0);
+    m->casadi_to_conopt_lb_row.resize(ng_);
+    m->casadi_to_conopt_ub_row.assign(ng_, -1);
 
     COI_Create(&m->cntvect);
 
     COIDEF_NumVar(m->cntvect, nx_);
-    COIDEF_NumCon(m->cntvect, ng_ + 1);
-    COIDEF_NumNz(m->cntvect, jac_rowno_.size());
+    // NumCon, NumNz, NumNlNz are set in solve() because range-constraint expansion
+    // can change them between calls.
 
     COIDEF_ObjCon(m->cntvect, 0);
-    COIDEF_OptDir(m->cntvect, 1);
+    COIDEF_OptDir(m->cntvect, -1);
 
     // Handle Options
     m->custom_options.clear();
@@ -188,8 +216,71 @@ namespace casadi {
   int ConoptInterface::solve(void* mem) const {
     auto m = static_cast<ConoptMemory*>(mem);
     m->cache_valid = false;
-    COI_Solve(m->cntvect);
-    m->success = (m->solsta == 1);
+    m->current_option_idx = 0;
+
+    // Build the per-solve constraint expansion (splits range constraints into two rows)
+    m->conopt_to_casadi.clear();
+    m->casadi_to_conopt_ub_row.assign(ng_, -1);
+    m->conopt_type.clear();
+    m->conopt_rhs.clear();
+
+    int ng_expanded = 0;
+    // Base NZ: objective gradient columns + all constraint Jacobian entries
+    int numnz = (int)gradf_sp_.nnz() + (int)jacg_sp_.nnz();
+
+    for (casadi_int i = 0; i < ng_; ++i) {
+      double lbg = m->d_nlp.lbz[nx_ + i];
+      double ubg = m->d_nlp.ubz[nx_ + i];
+      bool is_range = !std::isinf(lbg) && !std::isinf(ubg) && lbg != ubg;
+
+      m->casadi_to_conopt_lb_row[i] = ng_expanded + 1;  // 1-indexed CONOPT row
+      m->conopt_to_casadi.push_back((int)i);
+      if (lbg == ubg) {
+        m->conopt_type.push_back(0);  m->conopt_rhs.push_back(lbg);
+      } else if (!std::isinf(lbg) && std::isinf(ubg)) {
+        m->conopt_type.push_back(1);  m->conopt_rhs.push_back(lbg);
+      } else if (std::isinf(lbg) && !std::isinf(ubg)) {
+        m->conopt_type.push_back(2);  m->conopt_rhs.push_back(ubg);
+      } else if (std::isinf(lbg) && std::isinf(ubg)) {
+        m->conopt_type.push_back(3);  m->conopt_rhs.push_back(0.0);
+      } else {
+        m->conopt_type.push_back(1);  m->conopt_rhs.push_back(lbg);  // range: >= row
+      }
+      ng_expanded++;
+
+      if (is_range) {
+        m->casadi_to_conopt_ub_row[i] = ng_expanded + 1;
+        m->conopt_to_casadi.push_back((int)i);
+        m->conopt_type.push_back(2);  m->conopt_rhs.push_back(ubg);  // <= row
+        ng_expanded++;
+        numnz += jacg_rowstart_[i + 1] - jacg_rowstart_[i];
+      }
+    }
+    m->ng_expanded    = ng_expanded;
+    m->numnz_expanded = numnz;
+
+    COIDEF_NumCon(m->cntvect, ng_expanded + 1);
+    COIDEF_NumNz(m->cntvect, numnz);
+    COIDEF_NumNlNz(m->cntvect, numnz);
+
+    int ret = COI_Solve(m->cntvect);
+    if (ret != 0) {
+      // Hard error before status/solution callbacks were reached
+      m->success = false;
+      m->unified_return_status = SOLVER_RET_UNKNOWN;
+      return 0;
+    }
+
+    m->success = (m->modsta == 1 || m->modsta == 2) && m->solsta == 1;
+
+    if (!m->success) {
+      if (m->solsta == 2 || m->solsta == 3 || m->solsta == 5 ||
+          m->solsta == 8 || m->solsta == 15) {
+        m->unified_return_status = SOLVER_RET_LIMITED;
+      } else if (m->modsta == 4 || m->modsta == 5) {
+        m->unified_return_status = SOLVER_RET_INFEASIBLE;
+      }
+    }
     return 0;
   }
 
@@ -264,40 +355,45 @@ namespace casadi {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
-    for(int i = 0; i < NUMVAR; ++i) {
+    // Variable bounds and initial point
+    for (int i = 0; i < NUMVAR; ++i) {
       if (!std::isinf(m->d_nlp.lbz[i])) LOWER[i] = m->d_nlp.lbz[i];
       if (!std::isinf(m->d_nlp.ubz[i])) UPPER[i] = m->d_nlp.ubz[i];
-      CURR[i]  = m->d_nlp.z[i];
+      CURR[i] = m->d_nlp.z[i];
     }
 
+    // Constraint types and RHS (row 0 = objective, rows 1..ng_expanded = constraints)
     TYPEX[0] = 3;
-    RHS[0] = 0.0;
+    RHS[0]   = 0.0;
+    for (int r = 0; r < m->ng_expanded; ++r) {
+      TYPEX[r + 1] = m->conopt_type[r];
+      RHS[r + 1]   = m->conopt_rhs[r];
+    }
 
-    for(int i = 0; i < NUMCON - 1; ++i) {
-      double lbg = m->d_nlp.lbz[NUMVAR + i];
-      double ubg = m->d_nlp.ubz[NUMVAR + i];
-      int row_idx = i + 1;
-
-      if (lbg == ubg) {
-        TYPEX[row_idx] = 0;
-        RHS[row_idx] = lbg;
-      } else if (!std::isinf(lbg) && std::isinf(ubg)) {
-        TYPEX[row_idx] = 1;
-        RHS[row_idx] = lbg;
-      } else if (std::isinf(lbg) && !std::isinf(ubg)) {
-        TYPEX[row_idx] = 2;
-        RHS[row_idx] = ubg;
-      } else if (std::isinf(lbg) && std::isinf(ubg)) {
-        TYPEX[row_idx] = 3;
-        RHS[row_idx] = 0.0;
-      } else {
-        casadi_error("CONOPT does not accept range constraints.");
+    // Jacobian structure — built live from jacg_sp_ with range-row duplication
+    const casadi_int* g_colind = self.jacg_sp_.colind();
+    const casadi_int* g_row    = self.jacg_sp_.row();
+    int nz = 0;
+    for (int c = 0; c < NUMVAR; ++c) {
+      COLSTA[c] = nz;
+      if (self.gradf_col_flag_[c]) {
+        ROWNO[nz]  = 0;
+        NLFLAG[nz] = 1;
+        nz++;
+      }
+      for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
+        int ci = (int)g_row[el];
+        ROWNO[nz]  = m->casadi_to_conopt_lb_row[ci];
+        NLFLAG[nz] = 1;
+        nz++;
+        if (m->casadi_to_conopt_ub_row[ci] >= 0) {
+          ROWNO[nz]  = m->casadi_to_conopt_ub_row[ci];
+          NLFLAG[nz] = 1;
+          nz++;
+        }
       }
     }
-
-    std::memcpy(COLSTA, self.jac_colsta_.data(), (NUMVAR + 1) * sizeof(int));
-    std::memcpy(ROWNO, self.jac_rowno_.data(), NUMNZ * sizeof(int));
-    std::memcpy(NLFLAG, self.jac_nlflag_.data(), NUMNZ * sizeof(int));
+    COLSTA[NUMVAR] = nz;
 
     return 0;
   }
@@ -348,19 +444,12 @@ namespace casadi {
         }
     }
     else {
-        int g_rowno = ROWNO - 1;
-        if (MODE == 1 || MODE == 3) *G = m->cached_g[g_rowno];
+        int ci = m->conopt_to_casadi[ROWNO - 1];  // CasADi constraint index
+        if (MODE == 1 || MODE == 3) *G = m->cached_g[ci];
         if (MODE == 2 || MODE == 3) {
             std::memset(JAC, 0, NUMVAR * sizeof(double));
-            const casadi_int* colind = self.jacg_sp_.colind();
-            const casadi_int* row = self.jacg_sp_.row();
-            for (int c = 0; c < NUMVAR; ++c) {
-                for (casadi_int el = colind[c]; el < colind[c+1]; ++el) {
-                    if (row[el] == g_rowno) {
-                        JAC[c] = m->cached_jac_g[el];
-                    }
-                }
-            }
+            for (int k = self.jacg_rowstart_[ci]; k < self.jacg_rowstart_[ci + 1]; ++k)
+                JAC[self.jacg_col_[k]] = m->cached_jac_g[self.jacg_nzidx_[k]];
         }
     }
     return 0;
@@ -427,10 +516,37 @@ namespace casadi {
     m->iter = ITER;
     m->d_nlp.objective = OBJVAL;
 
-    if (SOLSTA == 1) m->return_status = "Optimal";
-    else if (SOLSTA >= 6 && SOLSTA <= 11) m->return_status = "No Solution (Major Error)";
-    else m->return_status = "Suboptimal/Infeasible";
+    const char* modsta_str;
+    switch (MODSTA) {
+      case 1:  modsta_str = "Optimal";                  break;
+      case 2:  modsta_str = "Locally optimal";          break;
+      case 3:  modsta_str = "Unbounded";                break;
+      case 4:  modsta_str = "Infeasible";               break;
+      case 5:  modsta_str = "Locally infeasible";       break;
+      case 6:  modsta_str = "Intermediate infeasible";  break;
+      case 7:  modsta_str = "Intermediate non-optimal"; break;
+      case 12: modsta_str = "Unknown error";            break;
+      case 13: modsta_str = "Error: no solution";       break;
+      default: modsta_str = "Unknown model status";     break;
+    }
 
+    const char* solsta_str;
+    switch (SOLSTA) {
+      case 1:  solsta_str = "Normal completion";                   break;
+      case 2:  solsta_str = "Iteration limit";                     break;
+      case 3:  solsta_str = "Time limit";                          break;
+      case 4:  solsta_str = "Terminated by solver";                break;
+      case 5:  solsta_str = "Evaluation error limit";              break;
+      case 8:  solsta_str = "User interrupt";                      break;
+      case 9:  solsta_str = "Setup failure";                       break;
+      case 10: solsta_str = "Major solver error";                  break;
+      case 11: solsta_str = "Major solver error (feasible point)"; break;
+      case 13: solsta_str = "System error";                        break;
+      case 15: solsta_str = "Quick Mode termination";              break;
+      default: solsta_str = "Unknown solver status";               break;
+    }
+
+    m->return_status = std::string(modsta_str) + " / " + std::string(solsta_str);
     return 0;
   }
 
@@ -438,9 +554,24 @@ namespace casadi {
     auto m = static_cast<ConoptMemory*>(USRMEM);
 
     casadi_copy(XVAL, NUMVAR, m->d_nlp.z);
-    casadi_copy(XMAR, NUMVAR, m->d_nlp.lam);
-    casadi_copy(YVAL + 1, NUMCON - 1, m->d_nlp.z + NUMVAR);
-    casadi_copy(YMAR + 1, NUMCON - 1, m->d_nlp.lam + NUMVAR);
+
+    // Constraint values: use the first CONOPT row for each CasADi constraint
+    // (both rows carry the same function value for range constraints)
+    for (casadi_int ci = 0; ci < m->self.ng_; ++ci)
+      m->d_nlp.z[NUMVAR + ci] = YVAL[m->casadi_to_conopt_lb_row[ci]];
+
+    // Variable marginals: CONOPT shadow prices = -CasADi lam_x
+    for (int i = 0; i < NUMVAR; ++i)
+      m->d_nlp.lam[i] = -XMAR[i];
+
+    // Constraint marginals: for range constraints sum both rows' shadow prices
+    // (only the active bound has a non-zero YMAR; summing is always safe)
+    for (casadi_int ci = 0; ci < m->self.ng_; ++ci) {
+      int row1 = m->casadi_to_conopt_lb_row[ci];
+      int row2 = m->casadi_to_conopt_ub_row[ci];
+      double ymar = YMAR[row1] + (row2 >= 0 ? YMAR[row2] : 0.0);
+      m->d_nlp.lam[NUMVAR + ci] = -ymar;
+    }
 
     return 0;
   }

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -370,12 +370,14 @@ namespace casadi {
       }
     }
 
-    // Evaluate objective gradient at initial point for constant entries
-    if (has_linear_gradf_) {
+    // Evaluate objective gradient at initial point for constant (linear) entries,
+    // or to capture the function value when the gradient is structurally empty.
+    m->obj_const_ = std::numeric_limits<double>::quiet_NaN();
+    if (has_linear_gradf_ || gradf_sp_.nnz() == 0) {
       m->arg[0] = m->d_nlp.z;
       m->arg[1] = m->d_nlp.p;
       m->res[0] = &m->cached_f;
-      m->res[1] = m->gradf_const_vals.data();
+      m->res[1] = has_linear_gradf_ ? m->gradf_const_vals.data() : nullptr;
       try {
         calc_function(m, "nlp_grad_f");
       } catch (std::exception& ex) {
@@ -384,6 +386,21 @@ namespace casadi {
       } catch (...) {
         casadi::uerr() << "CONOPT: initial evaluation failed (unknown exception)" << std::endl;
         return 1;
+      }
+    }
+
+    // Detect constant objective at solve time: no nonlinear gradient entries and
+    // all linear-gradient values are zero (objective has no x-dependence).
+    // Switch to feasibility mode so CONOPT doesn't report OBJVAL=0 for an empty row.
+    {
+      bool has_nl_gradf = std::any_of(gradf_nlflag_.begin(), gradf_nlflag_.end(),
+                                       [](int f) { return f == 1; });
+      bool all_const_zero = has_linear_gradf_ &&
+          std::all_of(m->gradf_const_vals.begin(), m->gradf_const_vals.end(),
+                      [](double v) { return v == 0.0; });
+      if (!has_nl_gradf && (gradf_sp_.nnz() == 0 || all_const_zero)) {
+        m->obj_const_ = m->cached_f;
+        COIDEF_OptDir(m->cntvect, 0);
       }
     }
 
@@ -409,6 +426,10 @@ namespace casadi {
     COIDEF_NumNlNz(m->cntvect, (int)num_nl_nz);
 
     int ret = COI_Solve(m->cntvect);
+
+    // Restore constant objective value when CONOPT ran in feasibility mode.
+    if (!std::isnan(m->obj_const_)) m->d_nlp.objective = m->obj_const_;
+
     if (ret != 0) {
       m->success = false;
       m->unified_return_status = m->nan_encountered ? SOLVER_RET_NAN : SOLVER_RET_UNKNOWN;

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -353,15 +353,15 @@ namespace casadi {
       ensure_row_capacity(ng_ - i);
       m->conopt_to_casadi.push_back((int)i);
       if (lbg == ubg) {
-        m->conopt_type.push_back(0);  m->conopt_rhs.push_back(lbg);
+        m->conopt_type.push_back(ConoptRowType::Equality);  m->conopt_rhs.push_back(lbg);
       } else if (!std::isinf(lbg) && std::isinf(ubg)) {
-        m->conopt_type.push_back(1);  m->conopt_rhs.push_back(lbg);
+        m->conopt_type.push_back(ConoptRowType::GreaterEqual);  m->conopt_rhs.push_back(lbg);
       } else if (std::isinf(lbg) && !std::isinf(ubg)) {
-        m->conopt_type.push_back(2);  m->conopt_rhs.push_back(ubg);
+        m->conopt_type.push_back(ConoptRowType::LessEqual);  m->conopt_rhs.push_back(ubg);
       } else if (std::isinf(lbg) && std::isinf(ubg)) {
-        m->conopt_type.push_back(3);  m->conopt_rhs.push_back(0.0);
+        m->conopt_type.push_back(ConoptRowType::Free);  m->conopt_rhs.push_back(0.0);
       } else {
-        m->conopt_type.push_back(1);  m->conopt_rhs.push_back(lbg);  // range: >= row
+        m->conopt_type.push_back(ConoptRowType::GreaterEqual);  m->conopt_rhs.push_back(lbg);  // range: >= row
       }
       ng_expanded++;
 
@@ -369,7 +369,7 @@ namespace casadi {
         m->casadi_to_conopt_ub_row[i] = (int)(ng_expanded + 1);
         ensure_row_capacity(ng_ - i);
         m->conopt_to_casadi.push_back((int)i);
-        m->conopt_type.push_back(2);  m->conopt_rhs.push_back(ubg);  // <= row
+        m->conopt_type.push_back(ConoptRowType::LessEqual);  m->conopt_rhs.push_back(ubg);  // <= row
         ng_expanded++;
         numnz += m->row_nnz[i];
       }
@@ -636,10 +636,10 @@ namespace casadi {
     }
 
     // Constraint types and RHS (row 0 = objective, rows 1..ng_expanded = constraints)
-    TYPEX[0] = 3;
+    TYPEX[0] = static_cast<int>(ConoptRowType::Free);
     RHS[0]   = 0.0;
     for (int r = 0; r < m->ng_expanded; ++r) {
-      TYPEX[r + 1] = m->conopt_type[r];
+      TYPEX[r + 1] = static_cast<int>(m->conopt_type[r]);
       RHS[r + 1]   = m->conopt_rhs[r];
     }
 
@@ -672,14 +672,14 @@ namespace casadi {
           int row1      = m->casadi_to_conopt_lb_row[ci];
           int row2      = m->casadi_to_conopt_ub_row[ci];
           if (r + 1 == row1) {
-            int ctype = m->conopt_type[r];  // type of this CONOPT expanded row
-            if (ctype == 0) {               // equality: both sides, just mark basic
+            ConoptRowType ctype = m->conopt_type[r];  // type of this CONOPT expanded row
+            if (ctype == ConoptRowType::Equality) {       // equality: both sides, just mark basic
               ESTA[r + 1] = 2;
-            } else if (ctype == 1) {        // >= row: active when lam_ci < 0
+            } else if (ctype == ConoptRowType::GreaterEqual) {  // >= row: active when lam_ci < 0
               ESTA[r + 1] = (lam_ci < 0.0) ? 0 : 2;
-            } else if (ctype == 2) {        // <= row (pure <= stored as lb_row): active when lam_ci > 0
+            } else if (ctype == ConoptRowType::LessEqual) {  // <= row (pure <= stored as lb_row): active when lam_ci > 0
               ESTA[r + 1] = (lam_ci > 0.0) ? 1 : 2;
-            } else {                        // free row (type=3): superbasic
+            } else {                        // free row: superbasic
               ESTA[r + 1] = 3;
             }
           } else if (r + 1 == row2) {
@@ -832,10 +832,12 @@ namespace casadi {
         if (MODE == 1 || MODE == 3) {
             *G = m->cached_g[ci];
             if (self.debug_) {
-                int ctype = m->conopt_type[ROWNO - 1];
+                ConoptRowType ctype = m->conopt_type[ROWNO - 1];
                 double rhs = m->conopt_rhs[ROWNO - 1];
-                const char* rel = (ctype == 0) ? "=" : (ctype == 1) ? ">=" : (ctype == 2) ? "<=" : "free";
-                if (ctype == 3)
+                const char* rel = (ctype == ConoptRowType::Equality) ? "=" :
+                                  (ctype == ConoptRowType::GreaterEqual) ? ">=" :
+                                  (ctype == ConoptRowType::LessEqual) ? "<=" : "free";
+                if (ctype == ConoptRowType::Free)
                     casadi::uout() << "  g[" << ci << "](x) = " << *G << " (free)\n";
                 else
                     casadi::uout() << "  g[" << ci << "](x) = " << *G << " " << rel << " " << rhs << "\n";

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -396,10 +396,10 @@ namespace casadi {
     }
 
     // Adjust conopt_rhs for fully linear rows to absorb constant terms.
-    // CONOPT's pre-triangular preprocessor uses only VALUE[] + RHS and never calls
-    // FDEval during that phase, so any constant in a fully linear constraint
-    // (e.g. x[9] - 3*x[6] + 133 = 0 → RHS must be -133, not 0) must be moved
-    // to the RHS here. For mixed (linear+nonlinear) rows, CONOPT calls FDEval and
+    // CONOPT doesn't call FDEval for purely linear rows, since these are evaluated internally.
+    // As such, it is necessary to store and constant terms in the RHS of the constraint,
+    // e.g. x[9] - 3*x[6] + 133 = 0 → RHS must be -133.
+    // For mixed (linear+nonlinear) rows, CONOPT calls FDEval and
     // gets the full function value including the constant, so no adjustment needed.
     if (has_linear_jac_) {
       const casadi_int* g_colind_c = jacg_sp_.colind();

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -23,7 +23,9 @@ namespace casadi {
 
   const Options ConoptInterface::options_ = {{&Nlpsol::options_}, {
       {"exact_hessian", {OT_BOOL, "Provide exact Hessian to CONOPT"}},
-      {"conopt", {OT_DICT, "Options to be passed to CONOPT"}}
+      {"warm_start", {OT_BOOL, "Warm-start CONOPT using multipliers from a prior solve to infer basis status (IniStat=2)"}},
+      {"conopt", {OT_DICT, "Options to be passed to CONOPT"}},
+      {"optfile", {OT_STRING, "Path to a CONOPT option file (for string-valued CR-cells such as Algorithm)"}}
   }};
 
   ConoptInterface::ConoptInterface(const std::string& name, const Function& nlp)
@@ -35,8 +37,11 @@ namespace casadi {
     Nlpsol::init(opts);
 
     // Extract native options
+    warm_start_ = false;
     for (auto&& op : opts) {
       if (op.first == "conopt") opts_ = op.second;
+      else if (op.first == "optfile") optfile_ = op.second.to_string();
+      else if (op.first == "warm_start") warm_start_ = op.second.to_bool();
     }
 
     create_function("nlp_f", {"x", "p"}, {"f"});
@@ -68,7 +73,6 @@ namespace casadi {
       Function hl_fcn = create_function("nlp_hess_l", {"x", "p", "lam:f", "lam:g"},
                                         {"tril:hess:gamma:x:x"}, {{"gamma", {"f", "g"}}});
       hesslag_sp_ = hl_fcn.sparsity_out(0);
-      alloc_w(hesslag_sp_.nnz(), true);
     }
 
     // Per-column objective-gradient flag (used in cb_read_matrix)
@@ -94,7 +98,7 @@ namespace casadi {
     const casadi_int* g_colind = jacg_sp_.colind();
     const casadi_int* g_row = jacg_sp_.row();
 
-    // Build row-indexed structure over nonlinear entries only (aligns with CONOPT's JACNUM)
+    // Build row-indexed CSR structure over nonlinear entries for fast Jacobian scatter in cb_fd_eval
     casadi_int nnz_g = jacg_sp_.nnz();
     jacg_rowstart_.assign(ng_ + 1, 0);
     for (casadi_int el = 0; el < nnz_g; ++el)
@@ -102,19 +106,17 @@ namespace casadi {
     for (int r = 0; r < ng_; ++r)
       jacg_rowstart_[r + 1] += jacg_rowstart_[r];
     jacg_nzidx_.resize(jacg_rowstart_[ng_]);
+    jacg_col_.resize(jacg_rowstart_[ng_]);
     std::vector<int> fill_pos(ng_, 0);
     for (int c = 0; c < nx_; ++c) {
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
         if (!jacg_nlflag_[el]) continue;
         int r = (int)g_row[el];
-        jacg_nzidx_[jacg_rowstart_[r] + fill_pos[r]++] = (int)el;
+        int pos = jacg_rowstart_[r] + fill_pos[r]++;
+        jacg_nzidx_[pos] = (int)el;
+        jacg_col_[pos]   = c;
       }
     }
-
-    alloc_w(1, true);
-    alloc_w(gradf_sp_.nnz(), true);
-    alloc_w(ng_, true);
-    alloc_w(jacg_sp_.nnz(), true);
   }
 
   // --- Serialization & Deserialization --- //
@@ -125,6 +127,8 @@ namespace casadi {
     s.unpack("ConoptInterface::gradf_sp", gradf_sp_);
     s.unpack("ConoptInterface::jacg_sp", jacg_sp_);
     s.unpack("ConoptInterface::hesslag_sp", hesslag_sp_);
+    s.unpack("ConoptInterface::optfile", optfile_);
+    s.unpack("ConoptInterface::warm_start", warm_start_);
 
     // Recompute linearity flags first (needed for CSR construction below)
     {
@@ -165,12 +169,15 @@ namespace casadi {
     for (int r = 0; r < ng_; ++r)
       jacg_rowstart_[r + 1] += jacg_rowstart_[r];
     jacg_nzidx_.resize(jacg_rowstart_[ng_]);
+    jacg_col_.resize(jacg_rowstart_[ng_]);
     std::vector<int> fill_pos(ng_, 0);
     for (int c = 0; c < nx_; ++c)
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
         if (!jacg_nlflag_[el]) continue;
         int r = (int)g_row[el];
-        jacg_nzidx_[jacg_rowstart_[r] + fill_pos[r]++] = (int)el;
+        int pos = jacg_rowstart_[r] + fill_pos[r]++;
+        jacg_nzidx_[pos] = (int)el;
+        jacg_col_[pos]   = c;
       }
   }
 
@@ -182,6 +189,8 @@ namespace casadi {
     s.pack("ConoptInterface::gradf_sp", gradf_sp_);
     s.pack("ConoptInterface::jacg_sp", jacg_sp_);
     s.pack("ConoptInterface::hesslag_sp", hesslag_sp_);
+    s.pack("ConoptInterface::optfile", optfile_);
+    s.pack("ConoptInterface::warm_start", warm_start_);
     // Derived arrays (gradf_col_flag_, CSR) are rebuilt on deserialization
   }
 
@@ -208,12 +217,15 @@ namespace casadi {
     m->cached_jac_g.resize(jacg_sp_.nnz(), 0.0);
     m->casadi_to_conopt_lb_row.resize(ng_);
     m->casadi_to_conopt_ub_row.assign(ng_, -1);
+    m->hess_lam_g_.resize(ng_, 0.0);
     if (has_linear_jac_)
       m->const_jac_vals.resize(jacg_sp_.nnz(), 0.0);
     if (has_linear_gradf_)
       m->gradf_const_vals.resize(gradf_sp_.nnz(), 0.0);
 
     COI_Create(&m->cntvect);
+
+    if (warm_start_) COIDEF_IniStat(m->cntvect, 2);
 
     COIDEF_NumVar(m->cntvect, nx_);
     // NumCon, NumNz, NumNlNz are set in solve() because range-constraint expansion
@@ -230,11 +242,16 @@ namespace casadi {
         else if (op.first == "errlim") COIDEF_ErrLim(m->cntvect, op.second.to_int());
         else if (op.first == "reslim") COIDEF_ResLim(m->cntvect, op.second.to_double());
         else if (op.first == "maxheap") COIDEF_MaxHeap(m->cntvect, op.second.to_double());
-        else {
+        else if (op.second.is_string()) {
+            casadi_warning("CONOPT option '" + op.first + "' is a string; string options cannot be "
+                           "passed via the CONOPT option callback (no SVAL parameter). "
+                           "Use the 'optfile' option instead.");
+        } else {
             // Push to custom options for the cb_option callback to feed dynamically
             m->custom_options.push_back(op);
         }
     }
+    if (!optfile_.empty()) COIDEF_Optfile(m->cntvect, optfile_.c_str());
     COIDEF_Option(m->cntvect, &ConoptInterface::cb_option);
     COIDEF_Progress(m->cntvect, &ConoptInterface::cb_progress);
 
@@ -328,8 +345,12 @@ namespace casadi {
       m->res[1] = m->const_jac_vals.data();
       try {
         calc_function(m, "nlp_jac_g");
+      } catch (std::exception& ex) {
+        casadi::uerr() << "CONOPT: initial evaluation failed: " << ex.what() << std::endl;
+        return 1;
       } catch (...) {
-        std::fill(m->const_jac_vals.begin(), m->const_jac_vals.end(), 0.0);
+        casadi::uerr() << "CONOPT: initial evaluation failed (unknown exception)" << std::endl;
+        return 1;
       }
     }
 
@@ -341,8 +362,12 @@ namespace casadi {
       m->res[1] = m->gradf_const_vals.data();
       try {
         calc_function(m, "nlp_grad_f");
+      } catch (std::exception& ex) {
+        casadi::uerr() << "CONOPT: initial evaluation failed: " << ex.what() << std::endl;
+        return 1;
       } catch (...) {
-        std::fill(m->gradf_const_vals.begin(), m->gradf_const_vals.end(), 0.0);
+        casadi::uerr() << "CONOPT: initial evaluation failed (unknown exception)" << std::endl;
+        return 1;
       }
     }
 
@@ -420,6 +445,25 @@ namespace casadi {
     if (opt.second.is_double())     *RVAL = opt.second.to_double();
     else if (opt.second.is_int())   *IVAL = opt.second.to_int();
     else if (opt.second.is_bool())  *LVAL = opt.second.to_bool() ? 1 : 0;
+    else if (opt.second.is_string()) {
+        // init_mem filters out all string options before they enter custom_options
+        // (with a casadi_warning directing the user to 'optfile'). Reaching this
+        // branch means custom_options was populated externally in a way that
+        // bypasses that filter, which is a programming error. Setting NAME[0]='\0'
+        // here would terminate the entire option enumeration, silently dropping
+        // all subsequent entries — so we assert rather than pretend to skip.
+        casadi_error("CONOPT option '" + opt.first + "' is a string type in cb_option. "
+                     "String options cannot be passed via the CONOPT option callback "
+                     "(COI_OPTION_t has no SVAL parameter). Use the 'optfile' option "
+                     "instead. The init_mem filter should have removed this option "
+                     "before it reached custom_options; reaching this branch is a "
+                     "programming error.");
+    } else {
+        // Similarly, an option of unknown type must never reach this point.
+        casadi_error("CONOPT option '" + opt.first + "' has an unknown GenericType in "
+                     "cb_option. Only double, int, and bool options are valid here. "
+                     "Reaching this branch is a programming error.");
+    }
 
     return 0;
   }
@@ -475,6 +519,55 @@ namespace casadi {
     for (int r = 0; r < m->ng_expanded; ++r) {
       TYPEX[r + 1] = m->conopt_type[r];
       RHS[r + 1]   = m->conopt_rhs[r];
+    }
+
+    if (self.warm_start_) {
+      // Always zero-initialise so that skipping the fill below is safe.
+      std::fill(VSTA, VSTA + NUMVAR, 0);
+      std::fill(ESTA, ESTA + NUMCON, 0);
+      ESTA[0] = 3;  // objective row always superbasic
+
+      const double* lam = m->d_nlp.lam;
+      bool all_zero = std::all_of(lam, lam + self.nx_ + self.ng_,
+                                  [](double v) { return v == 0.0; });
+      if (!all_zero) {
+        for (int i = 0; i < NUMVAR; ++i) {
+          double lbi = m->d_nlp.lbz[i];
+          double ubi = m->d_nlp.ubz[i];
+          double xi  = m->d_nlp.z[i];
+          double li  = lam[i];
+          if (!std::isinf(lbi) && std::fabs(xi - lbi) < 1e-8 && li <= 0.0)
+            VSTA[i] = 0;
+          else if (!std::isinf(ubi) && std::fabs(xi - ubi) < 1e-8 && li >= 0.0)
+            VSTA[i] = 1;
+          else
+            VSTA[i] = 2;
+        }
+
+        for (int r = 0; r < m->ng_expanded; ++r) {
+          int ci        = m->conopt_to_casadi[r];
+          double lam_ci = lam[NUMVAR + ci];
+          int row1      = m->casadi_to_conopt_lb_row[ci];
+          int row2      = m->casadi_to_conopt_ub_row[ci];
+          if (r + 1 == row1) {
+            int ctype = m->conopt_type[r];  // type of this CONOPT expanded row
+            if (ctype == 0) {               // equality: both sides, just mark basic
+              ESTA[r + 1] = 2;
+            } else if (ctype == 1) {        // >= row: active when lam_ci < 0
+              ESTA[r + 1] = (lam_ci < 0.0) ? 0 : 2;
+            } else if (ctype == 2) {        // <= row (pure <= stored as lb_row): active when lam_ci > 0
+              ESTA[r + 1] = (lam_ci > 0.0) ? 1 : 2;
+            } else {                        // free row (type=3): superbasic
+              ESTA[r + 1] = 3;
+            }
+          } else if (r + 1 == row2) {
+            // range ub side is active when lam_ci > 0
+            ESTA[r + 1] = (lam_ci > 0.0) ? 1 : 2;
+          } else {
+            ESTA[r + 1] = 2;
+          }
+        }
+      }
     }
 
     // Jacobian structure — built live from jacg_sp_ with range-row duplication
@@ -570,18 +663,18 @@ namespace casadi {
     if (ROWNO == 0) {
         if (MODE == 1 || MODE == 3) *G = m->cached_f;
         if (MODE == 2 || MODE == 3) {
-            std::memset(JAC, 0, NUMVAR * sizeof(double));
             const casadi_int* f_row = self.gradf_sp_.row();
             for (casadi_int k = 0; k < self.gradf_sp_.nnz(); ++k)
-                JAC[f_row[k]] = m->cached_grad_f[k];
+                if (self.gradf_nlflag_[k]) JAC[f_row[k]] = m->cached_grad_f[k];
         }
     } else {
         int ci = m->conopt_to_casadi[ROWNO - 1];
         if (MODE == 1 || MODE == 3) *G = m->cached_g[ci];
         if (MODE == 2 || MODE == 3) {
-            int base = self.jacg_rowstart_[ci];
-            for (int k = 0; k < NUMJAC; ++k)
-                JAC[JACNUM[k]] = m->cached_jac_g[self.jacg_nzidx_[base + k]];
+            int base  = self.jacg_rowstart_[ci];
+            int count = self.jacg_rowstart_[ci + 1] - self.jacg_rowstart_[ci];
+            for (int k = 0; k < count; ++k)
+                JAC[self.jacg_col_[base + k]] = m->cached_jac_g[self.jacg_nzidx_[base + k]];
         }
     }
     return 0;
@@ -625,12 +718,17 @@ namespace casadi {
     const ConoptInterface& self = m->self;
 
     double obj_factor = U[0];
-    const double* lam_g = &U[1];
+
+    for (int ci = 0; ci < self.ng_; ++ci) {
+      int row1 = m->casadi_to_conopt_lb_row[ci];
+      int row2 = m->casadi_to_conopt_ub_row[ci];
+      m->hess_lam_g_[ci] = -(U[row1] + (row2 >= 0 ? U[row2] : 0.0));
+    }
 
     m->arg[0] = X;
     m->arg[1] = m->d_nlp.p;
     m->arg[2] = &obj_factor;
-    m->arg[3] = lam_g;
+    m->arg[3] = m->hess_lam_g_.data();
     m->res[0] = HSVL;
 
     try {

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -552,11 +552,16 @@ namespace casadi {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
-    // Variable bounds and initial point
+    // Variable bounds and initial point (clamped to [lb, ub])
     for (int i = 0; i < NUMVAR; ++i) {
-      if (!std::isinf(m->d_nlp.lbz[i])) LOWER[i] = m->d_nlp.lbz[i];
-      if (!std::isinf(m->d_nlp.ubz[i])) UPPER[i] = m->d_nlp.ubz[i];
-      CURR[i] = m->d_nlp.z[i];
+      double lb = m->d_nlp.lbz[i];
+      double ub = m->d_nlp.ubz[i];
+      if (!std::isinf(lb)) LOWER[i] = lb;
+      if (!std::isinf(ub)) UPPER[i] = ub;
+      double x0 = m->d_nlp.z[i];
+      if (!std::isinf(lb)) x0 = std::max(x0, lb);
+      if (!std::isinf(ub)) x0 = std::min(x0, ub);
+      CURR[i] = x0;
     }
 
     // Constraint types and RHS (row 0 = objective, rows 1..ng_expanded = constraints)

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -645,9 +645,9 @@ namespace casadi {
 
     if (self.warm_start_) {
       // Always zero-initialise so that skipping the fill below is safe.
-      std::fill(VSTA, VSTA + NUMVAR, 0);
-      std::fill(ESTA, ESTA + NUMCON, 0);
-      ESTA[0] = 3;  // objective row always superbasic
+      std::fill(VSTA, VSTA + NUMVAR, static_cast<int>(ConoptBasisStatus::AtLower));
+      std::fill(ESTA, ESTA + NUMCON, static_cast<int>(ConoptBasisStatus::AtLower));
+      ESTA[0] = static_cast<int>(ConoptBasisStatus::SuperBasic);  // objective row always superbasic
 
       const double* lam = m->d_nlp.lam;
       bool all_zero = std::all_of(lam, lam + self.nx_ + self.ng_,
@@ -659,11 +659,11 @@ namespace casadi {
           double xi  = m->d_nlp.z[i];
           double li  = lam[i];
           if (!std::isinf(lbi) && std::fabs(xi - lbi) < 1e-8 && li <= 0.0)
-            VSTA[i] = 0;
+            VSTA[i] = static_cast<int>(ConoptBasisStatus::AtLower);
           else if (!std::isinf(ubi) && std::fabs(xi - ubi) < 1e-8 && li >= 0.0)
-            VSTA[i] = 1;
+            VSTA[i] = static_cast<int>(ConoptBasisStatus::AtUpper);
           else
-            VSTA[i] = 2;
+            VSTA[i] = static_cast<int>(ConoptBasisStatus::Basic);
         }
 
         for (int r = 0; r < m->ng_expanded; ++r) {
@@ -674,19 +674,22 @@ namespace casadi {
           if (r + 1 == row1) {
             ConoptRowType ctype = m->conopt_type[r];  // type of this CONOPT expanded row
             if (ctype == ConoptRowType::Equality) {       // equality: both sides, just mark basic
-              ESTA[r + 1] = 2;
+              ESTA[r + 1] = static_cast<int>(ConoptBasisStatus::Basic);
             } else if (ctype == ConoptRowType::GreaterEqual) {  // >= row: active when lam_ci < 0
-              ESTA[r + 1] = (lam_ci < 0.0) ? 0 : 2;
+              ESTA[r + 1] = static_cast<int>(
+                  (lam_ci < 0.0) ? ConoptBasisStatus::AtLower : ConoptBasisStatus::Basic);
             } else if (ctype == ConoptRowType::LessEqual) {  // <= row (pure <= stored as lb_row): active when lam_ci > 0
-              ESTA[r + 1] = (lam_ci > 0.0) ? 1 : 2;
+              ESTA[r + 1] = static_cast<int>(
+                  (lam_ci > 0.0) ? ConoptBasisStatus::AtUpper : ConoptBasisStatus::Basic);
             } else {                        // free row: superbasic
-              ESTA[r + 1] = 3;
+              ESTA[r + 1] = static_cast<int>(ConoptBasisStatus::SuperBasic);
             }
           } else if (r + 1 == row2) {
             // range ub side is active when lam_ci > 0
-            ESTA[r + 1] = (lam_ci > 0.0) ? 1 : 2;
+            ESTA[r + 1] = static_cast<int>(
+                (lam_ci > 0.0) ? ConoptBasisStatus::AtUpper : ConoptBasisStatus::Basic);
           } else {
-            ESTA[r + 1] = 2;
+            ESTA[r + 1] = static_cast<int>(ConoptBasisStatus::Basic);
           }
         }
       }

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -1,6 +1,7 @@
 #include "conopt_interface.hpp"
 #include "casadi/core/casadi_misc.hpp"
 #include "casadi/core/casadi_interrupt.hpp"
+#include <cassert>
 #include <cmath>
 #include <cstring>
 #include <algorithm>
@@ -93,8 +94,9 @@ namespace casadi {
       Sparsity dgradf_dx = gradf_fcn.sparsity_jac(0, 1, true);
       gradf_nlflag_.assign(gradf_sp_.nnz(), 0);
       const casadi_int* dg_row = dgradf_dx.row();
-      for (casadi_int el = 0; el < dgradf_dx.nnz(); ++el)
+      for (casadi_int el = 0; el < dgradf_dx.nnz(); ++el) {
         gradf_nlflag_[dg_row[el]] = 1;
+      }
       has_linear_gradf_ = std::any_of(gradf_nlflag_.begin(), gradf_nlflag_.end(),
                                        [](int f) { return f == 0; });
     }
@@ -317,8 +319,9 @@ namespace casadi {
     }
 
     casadi_int ng_expanded = 0;
-    // Base NZ: objective gradient columns + all constraint Jacobian entries
-    casadi_int numnz = (casadi_int)gradf_sp_.nnz() + (casadi_int)jacg_sp_.nnz();
+    // Objective gradient NZs are added to numnz after nlp_grad_f is evaluated
+    // (so that gradf_const_vals is populated before we check for non-zero linear entries).
+    casadi_int numnz = (casadi_int)jacg_sp_.nnz();
 
     for (casadi_int i = 0; i < ng_; ++i) {
       double lbg = m->d_nlp.lbz[nx_ + i];
@@ -349,9 +352,7 @@ namespace casadi {
       }
     }
     casadi_assert(ng_expanded <= std::numeric_limits<int>::max(), "ng_expanded overflows int");
-    casadi_assert(numnz       <= std::numeric_limits<int>::max(), "numnz overflows int");
-    m->ng_expanded    = (int)ng_expanded;
-    m->numnz_expanded = (int)numnz;
+    m->ng_expanded = (int)ng_expanded;
 
     // Evaluate Jacobian at the initial point to obtain values for constant entries
     if (has_linear_jac_) {
@@ -367,6 +368,37 @@ namespace casadi {
       } catch (...) {
         casadi::uerr() << "CONOPT: initial evaluation failed (unknown exception)" << std::endl;
         return 1;
+      }
+    }
+
+    // Adjust conopt_rhs for fully linear rows to absorb constant terms.
+    // CONOPT's pre-triangular preprocessor uses only VALUE[] + RHS and never calls
+    // FDEval during that phase, so any constant in a fully linear constraint
+    // (e.g. x[9] - 3*x[6] + 133 = 0 → RHS must be -133, not 0) must be moved
+    // to the RHS here. For mixed (linear+nonlinear) rows, CONOPT calls FDEval and
+    // gets the full function value including the constant, so no adjustment needed.
+    if (has_linear_jac_) {
+      const casadi_int* g_colind_c = jacg_sp_.colind();
+      const casadi_int* g_row_c    = jacg_sp_.row();
+
+      // Accumulate the linear part of G at x0 per row: sum_j a_j * x0_j
+      std::vector<double> linear_at_x0(ng_, 0.0);
+      for (int c = 0; c < nx_; ++c) {
+        for (casadi_int el = g_colind_c[c]; el < g_colind_c[c + 1]; ++el) {
+          if (jacg_nlflag_[el] == 0)
+            linear_at_x0[g_row_c[el]] += m->const_jac_vals[el] * m->d_nlp.z[c];
+        }
+      }
+
+      for (int ci = 0; ci < ng_; ++ci) {
+        // Only adjust fully linear rows (no nonlinear Jacobian entries)
+        if (jacg_rowstart_[ci + 1] != jacg_rowstart_[ci]) continue;
+        double constant = m->cached_g[ci] - linear_at_x0[ci];
+        if (std::abs(constant) < 1e-14) continue;
+        int lb_row = m->casadi_to_conopt_lb_row[ci];
+        m->conopt_rhs[lb_row - 1] -= constant;
+        int ub_row = m->casadi_to_conopt_ub_row[ci];
+        if (ub_row >= 0) m->conopt_rhs[ub_row - 1] -= constant;
       }
     }
 
@@ -420,6 +452,22 @@ namespace casadi {
     }
 
     casadi_assert(num_nl_nz <= std::numeric_limits<int>::max(), "num_nl_nz overflows int");
+
+    // Count objective gradient NZs now that gradf_const_vals has been populated.
+    // Nonlinear entries are always included; linear (constant) entries only when
+    // non-zero — a zero constant gradient contributes nothing to the objective row
+    // and must not occupy a slot in the CONOPT matrix structure.
+    {
+      casadi_int numnz_f = 0;
+      for (casadi_int k = 0; k < (casadi_int)gradf_sp_.nnz(); ++k) {
+        if (gradf_nlflag_[k] == 1 ||
+            (has_linear_gradf_ && m->gradf_const_vals[k] != 0.0))
+          numnz_f++;
+      }
+      numnz += numnz_f;
+    }
+    casadi_assert(numnz <= std::numeric_limits<int>::max(), "numnz overflows int");
+    m->numnz_expanded = (int)numnz;
 
     COIDEF_NumCon(m->cntvect, (int)(ng_expanded + 1));
     COIDEF_NumNz(m->cntvect, (int)numnz);
@@ -629,10 +677,16 @@ namespace casadi {
       COLSTA[c] = nz;
       if (self.gradf_col_flag_[c]) {
         casadi_int k = self.gradf_col_to_nz_[c];
-        ROWNO[nz]  = 0;
-        NLFLAG[nz] = self.gradf_nlflag_[k];
-        if (self.gradf_nlflag_[k] == 0) VALUE[nz] = m->gradf_const_vals[k];
-        nz++;
+        if (self.gradf_nlflag_[k] == 1) {
+          ROWNO[nz]  = 0;
+          NLFLAG[nz] = 1;
+          nz++;
+        } else if (m->gradf_const_vals[k] != 0.0) {
+          ROWNO[nz]  = 0;
+          NLFLAG[nz] = 0;
+          VALUE[nz]  = m->gradf_const_vals[k];
+          nz++;
+        }
       }
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
         int ci = (int)g_row[el];

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -227,9 +227,13 @@ namespace casadi {
     m->casadi_to_conopt_ub_row.assign(ng_, -1);
     m->hess_lam_g_.resize(ng_, 0.0);
     m->row_nnz.assign(ng_, 0);
-    m->conopt_to_casadi.reserve(ng_ * 2);  // worst-case: all constraints are range
-    m->conopt_type.reserve(ng_ * 2);
-    m->conopt_rhs.reserve(ng_ * 2);
+    // Most problems have few or no range constraints, so reserve a fraction of
+    // the worst case (all rows range); solve() grows these
+    // vectors on demand as rows are actually expanded.
+    casadi_int initial_row_reserve = std::max<casadi_int>(1, ng_ / 4);
+    m->conopt_to_casadi.reserve(initial_row_reserve);
+    m->conopt_type.reserve(initial_row_reserve);
+    m->conopt_rhs.reserve(initial_row_reserve);
     if (has_linear_jac_)
       m->const_jac_vals.resize(jacg_sp_.nnz(), 0.0);
     if (has_linear_gradf_)
@@ -323,12 +327,29 @@ namespace casadi {
     // (so that gradf_const_vals is populated before we check for non-zero linear entries).
     casadi_int numnz = (casadi_int)jacg_sp_.nnz();
 
+    // conopt_to_casadi/conopt_type/conopt_rhs always grow in lockstep, so a single
+    // capacity check (on conopt_to_casadi) is enough to decide whether to grow all
+    // three. Growth is by 0.25 of the CasADi rows not yet processed, rather than
+    // jumping straight to the worst-case (all-range) size.
+    auto ensure_row_capacity = [m](casadi_int remaining_rows) {
+      if (m->conopt_to_casadi.size() == m->conopt_to_casadi.capacity()) {
+        casadi_int new_cap = m->conopt_to_casadi.capacity() +
+                              std::max<casadi_int>(std::min<casadi_int>(remaining_rows, 10), remaining_rows / 4);
+        m->conopt_to_casadi.reserve(new_cap);
+        m->conopt_type.reserve(new_cap);
+        m->conopt_rhs.reserve(new_cap);
+      }
+    };
+
     for (casadi_int i = 0; i < ng_; ++i) {
       double lbg = m->d_nlp.lbz[nx_ + i];
       double ubg = m->d_nlp.ubz[nx_ + i];
       bool is_range = !std::isinf(lbg) && !std::isinf(ubg) && lbg != ubg;
 
-      m->casadi_to_conopt_lb_row[i] = (int)(ng_expanded + 1);  // 1-indexed CONOPT row
+      // CONOPT row 0 is reserved for the objective, so constraint rows start at 1
+      // (arrays are still plain 0-based C arrays; only the row *numbering* is offset).
+      m->casadi_to_conopt_lb_row[i] = (int)(ng_expanded + 1);
+      ensure_row_capacity(ng_ - i);
       m->conopt_to_casadi.push_back((int)i);
       if (lbg == ubg) {
         m->conopt_type.push_back(0);  m->conopt_rhs.push_back(lbg);
@@ -345,6 +366,7 @@ namespace casadi {
 
       if (is_range) {
         m->casadi_to_conopt_ub_row[i] = (int)(ng_expanded + 1);
+        ensure_row_capacity(ng_ - i);
         m->conopt_to_casadi.push_back((int)i);
         m->conopt_type.push_back(2);  m->conopt_rhs.push_back(ubg);  // <= row
         ng_expanded++;

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -26,7 +26,8 @@ namespace casadi {
       {"exact_hessian", {OT_BOOL, "Provide exact Hessian to CONOPT"}},
       {"warm_start", {OT_BOOL, "Warm-start CONOPT using multipliers from a prior solve to infer basis status (IniStat=2)"}},
       {"conopt", {OT_DICT, "Options to be passed to CONOPT"}},
-      {"optfile", {OT_STRING, "Path to a CONOPT option file (for string-valued CR-cells such as Algorithm)"}}
+      {"optfile", {OT_STRING, "Path to a CONOPT option file (for string-valued CR-cells such as Algorithm)"}},
+      {"debug", {OT_BOOL, "Print debug output: constraint values at each FDEval, solution vector, and option echo"}}
   }};
 
   ConoptInterface::ConoptInterface(const std::string& name, const Function& nlp)
@@ -39,10 +40,12 @@ namespace casadi {
 
     // Extract native options
     warm_start_ = false;
+    debug_ = false;
     for (auto&& op : opts) {
       if (op.first == "conopt") opts_ = op.second;
       else if (op.first == "optfile") optfile_ = op.second.to_string();
       else if (op.first == "warm_start") warm_start_ = op.second.to_bool();
+      else if (op.first == "debug") debug_ = op.second.to_bool();
     }
 
     create_function("nlp_f", {"x", "p"}, {"f"});
@@ -130,6 +133,7 @@ namespace casadi {
     s.unpack("ConoptInterface::hesslag_sp", hesslag_sp_);
     s.unpack("ConoptInterface::optfile", optfile_);
     s.unpack("ConoptInterface::warm_start", warm_start_);
+    s.unpack("ConoptInterface::debug", debug_);
 
     // Recompute linearity flags first (needed for CSR construction below)
     {
@@ -192,6 +196,7 @@ namespace casadi {
     s.pack("ConoptInterface::hesslag_sp", hesslag_sp_);
     s.pack("ConoptInterface::optfile", optfile_);
     s.pack("ConoptInterface::warm_start", warm_start_);
+    s.pack("ConoptInterface::debug", debug_);
     // Derived arrays (gradf_col_flag_, CSR) are rebuilt on deserialization
   }
 
@@ -455,9 +460,16 @@ namespace casadi {
     auto& opt = m->custom_options[NCALL];
     std::strcpy(NAME, opt.first.c_str());
 
-    if (opt.second.is_double())     *RVAL = opt.second.to_double();
-    else if (opt.second.is_int())   *IVAL = opt.second.to_int();
-    else if (opt.second.is_bool())  *LVAL = opt.second.to_bool() ? 1 : 0;
+    if (opt.second.is_double()) {
+        *RVAL = opt.second.to_double();
+        if (m->self.debug_) casadi::uout() << "CONOPT option: " << opt.first << " = " << *RVAL << std::endl;
+    } else if (opt.second.is_int()) {
+        *IVAL = opt.second.to_int();
+        if (m->self.debug_) casadi::uout() << "CONOPT option: " << opt.first << " = " << *IVAL << std::endl;
+    } else if (opt.second.is_bool()) {
+        *LVAL = opt.second.to_bool() ? 1 : 0;
+        if (m->self.debug_) casadi::uout() << "CONOPT option: " << opt.first << " = " << (opt.second.to_bool() ? "true" : "false") << std::endl;
+    }
     else if (opt.second.is_string()) {
         // init_mem filters out all string options before they enter custom_options
         // (with a casadi_warning directing the user to 'optfile'). Reaching this
@@ -622,6 +634,13 @@ namespace casadi {
 
     std::memcpy(m->cached_x.data(), X, NUMVAR * sizeof(double));
 
+    if (self.debug_) {
+        casadi::uout() << "FDEvalIni x:";
+        for (int i = 0; i < NUMVAR; ++i)
+            casadi::uout() << " " << X[i];
+        casadi::uout() << "\n";
+    }
+
     const bool need_jac = (MODE != 1);
 
     try {
@@ -697,12 +716,28 @@ namespace casadi {
         if (MODE == 1 || MODE == 3) *G = m->cached_f;
         if (MODE == 2 || MODE == 3) {
             const casadi_int* f_row = self.gradf_sp_.row();
-            for (casadi_int k = 0; k < self.gradf_sp_.nnz(); ++k)
-                if (self.gradf_nlflag_[k]) JAC[f_row[k]] = m->cached_grad_f[k];
+            for (casadi_int k = 0; k < self.gradf_sp_.nnz(); ++k) {
+                if (self.gradf_nlflag_[k]) {
+                    JAC[f_row[k]] = m->cached_grad_f[k];
+                    if (self.debug_)
+                        casadi::uout() << "  df/dx[" << f_row[k] << "] = " << m->cached_grad_f[k] << "\n";
+                }
+            }
         }
     } else {
         int ci = m->conopt_to_casadi[ROWNO - 1];
-        if (MODE == 1 || MODE == 3) *G = m->cached_g[ci];
+        if (MODE == 1 || MODE == 3) {
+            *G = m->cached_g[ci];
+            if (self.debug_) {
+                int ctype = m->conopt_type[ROWNO - 1];
+                double rhs = m->conopt_rhs[ROWNO - 1];
+                const char* rel = (ctype == 0) ? "=" : (ctype == 1) ? ">=" : (ctype == 2) ? "<=" : "free";
+                if (ctype == 3)
+                    casadi::uout() << "  g[" << ci << "](x) = " << *G << " (free)\n";
+                else
+                    casadi::uout() << "  g[" << ci << "](x) = " << *G << " " << rel << " " << rhs << "\n";
+            }
+        }
         if (MODE == 2 || MODE == 3) {
             // Guard against stale Jacobian: cache_valid_jac is false when cb_fdevalini
             // was called with MODE==1 and skipped Jacobian computation.
@@ -712,8 +747,13 @@ namespace casadi {
             }
             int base  = self.jacg_rowstart_[ci];
             int count = self.jacg_rowstart_[ci + 1] - self.jacg_rowstart_[ci];
-            for (int k = 0; k < count; ++k)
-                JAC[self.jacg_col_[base + k]] = m->cached_jac_g[self.jacg_nzidx_[base + k]];
+            for (int k = 0; k < count; ++k) {
+                int col = self.jacg_col_[base + k];
+                double val = m->cached_jac_g[self.jacg_nzidx_[base + k]];
+                JAC[col] = val;
+                if (self.debug_)
+                    casadi::uout() << "  dg[" << ci << "]/dx[" << col << "] = " << val << "\n";
+            }
         }
     }
     return 0;
@@ -765,7 +805,13 @@ namespace casadi {
     for (int ci = 0; ci < self.ng_; ++ci) {
       int row1 = m->casadi_to_conopt_lb_row[ci];
       int row2 = m->casadi_to_conopt_ub_row[ci];
-      m->hess_lam_g_[ci] = -(U[row1] + (row2 >= 0 ? U[row2] : 0.0));
+    }
+
+    if (self.debug_) {
+        casadi::uout() << "Hessian lam_f=" << obj_factor << " lam_g:";
+        for (int ci = 0; ci < self.ng_; ++ci)
+            casadi::uout() << " " << m->hess_lam_g_[ci];
+        casadi::uout() << "\n";
     }
 
     m->arg[0] = X;
@@ -776,7 +822,17 @@ namespace casadi {
 
     try {
         self.calc_function(m, "nlp_hess_l");
+        if (self.debug_) {
+            casadi::uout() << "Hessian values (HSVL):";
+            for (int i = 0; i < NHESS; ++i)
+                casadi::uout() << " " << HSVL[i];
+            casadi::uout() << "\n";
+        }
+    } catch (std::exception& ex) {
+        casadi::uerr() << "CONOPT: nlp_hess_l failed: " << ex.what() << std::endl;
+        *NODRV = 1;
     } catch (...) {
+        casadi::uerr() << "CONOPT: nlp_hess_l failed (unknown exception)" << std::endl;
         *NODRV = 1;
     }
     return 0;
@@ -828,6 +884,13 @@ namespace casadi {
 
     casadi_copy(XVAL, NUMVAR, m->d_nlp.z);
 
+    if (m->self.debug_) {
+        casadi::uout() << "Solution x:";
+        for (int i = 0; i < NUMVAR; ++i)
+            casadi::uout() << " " << XVAL[i];
+        casadi::uout() << "\n";
+    }
+
     // Constraint values: use the first CONOPT row for each CasADi constraint
     // (both rows carry the same function value for range constraints)
     for (casadi_int ci = 0; ci < m->self.ng_; ++ci)
@@ -850,7 +913,12 @@ namespace casadi {
   }
 
   int COI_CALLCONV ConoptInterface::cb_message(int SMSG, int DMSG, int NMSG, char* MSGV[], void* USRMEM) {
-    for (int i = 0; i < std::min(SMSG, NMSG); ++i) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+
+    int message_length = SMSG;
+    if (m->self.debug_) message_length = std::max(message_length, std::max(DMSG, NMSG));
+
+    for (int i = 0; i < message_length; ++i) {
         if (MSGV[i] != nullptr) {
             casadi::uout() << MSGV[i] << std::endl;
         }

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -649,7 +649,9 @@ namespace casadi {
       CURR[i] = x0;
     }
 
-    // Constraint types and RHS (row 0 = objective, rows 1..ng_expanded = constraints)
+    // Constraint types and RHS (row 0 = objective, rows 1..ng_expanded = constraints).
+    // conopt_type/conopt_rhs come from solve()'s range-constraint expansion —
+    // they depend on this call's numeric lbg/ubg, not just problem structure.
     TYPEX[0] = static_cast<int>(ConoptRowType::Free);
     RHS[0]   = 0.0;
     for (int r = 0; r < m->ng_expanded; ++r) {
@@ -658,8 +660,12 @@ namespace casadi {
     }
 
     if (self.warm_start_) {
+      // conopt_to_casadi/casadi_to_conopt_lb_row/ub_row (from solve()) map each
+      // expanded CONOPT row back to its CasADi constraint, to look up lam there.
       ESTA[0] = static_cast<int>(ConoptBasisStatus::SuperBasic);  // objective row always superbasic
 
+      // lam is the prior solve's dual solution, length nx_+ng_. lam[0..nx_-1] are
+      // variable-bound multipliers, lam[nx_..] are constraint multipliers.
       const double* lam = m->d_nlp.lam;
       bool all_zero = std::all_of(lam, lam + self.nx_ + self.ng_,
                                   [](double v) { return v == 0.0; });
@@ -668,7 +674,7 @@ namespace casadi {
           double lbi = m->d_nlp.lbz[i];
           double ubi = m->d_nlp.ubz[i];
           double xi  = m->d_nlp.z[i];
-          double li  = lam[i];
+          double li  = lam[i];  // nonzero multiplier => that bound is active, so nonbasic
           if (!std::isinf(lbi) && std::fabs(xi - lbi) < 1e-8 && li <= 0.0)
             VSTA[i] = static_cast<int>(ConoptBasisStatus::AtLower);
           else if (!std::isinf(ubi) && std::fabs(xi - ubi) < 1e-8 && li >= 0.0)
@@ -679,7 +685,7 @@ namespace casadi {
 
         for (int r = 0; r < m->ng_expanded; ++r) {
           int ci        = m->conopt_to_casadi[r];
-          double lam_ci = lam[NUMVAR + ci];
+          double lam_ci = lam[NUMVAR + ci];  // this constraint's multiplier, same sign logic as above
           int row1      = m->casadi_to_conopt_lb_row[ci];
           int row2      = m->casadi_to_conopt_ub_row[ci];
           if (r + 1 == row1) {
@@ -706,13 +712,18 @@ namespace casadi {
       }
     }
 
-    // Jacobian structure — built live from jacg_sp_ with range-row duplication
+    // Jacobian structure — built live from jacg_sp_ with range-row duplication.
+    // Column/sparsity/linearity data (jacg_sp_, gradf_col_flag_, gradf_col_to_nz_,
+    // gradf_nlflag_, jacg_nlflag_) is structural, fixed since init(). Row mapping
+    // (casadi_to_conopt_lb_row/ub_row) and numeric values (gradf_const_vals,
+    // const_jac_vals) are this solve()'s numeric data.
     const casadi_int* g_colind = self.jacg_sp_.colind();
     const casadi_int* g_row    = self.jacg_sp_.row();
     int nz = 0;
     for (int c = 0; c < NUMVAR; ++c) {
       COLSTA[c] = nz;
       if (self.gradf_col_flag_[c]) {
+        // Objective-gradient entry in column c, if any (row 0 = objective).
         casadi_int k = self.gradf_col_to_nz_[c];
         if (self.gradf_nlflag_[k] == 1) {
           ROWNO[nz]  = 0;
@@ -725,6 +736,8 @@ namespace casadi {
           nz++;
         }
       }
+      // Constraint-Jacobian entries in column c; duplicated onto the ub row too
+      // when this CasADi row was split into a range constraint by solve().
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
         int ci = (int)g_row[el];
         int nlflag = self.jacg_nlflag_[el];
@@ -919,7 +932,6 @@ namespace casadi {
 
     // CONOPT's Lagrangian: L = SUM(r) U(r) * F(r), so d²L/dx² = SUM(r) U(r) * d²F(r)/dx².
     // CasADi computes lam_f*d²f/dx² + lam_g^T*d²g/dx², so lam_f = U[0], lam_g[ci] = U[row_ci].
-    // No sign flip: CONOPT's U is the Lagrangian weight directly, not the shadow price (YMAR).
     double obj_factor = U[0];
 
     for (int ci = 0; ci < self.ng_; ++ci) {

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -11,7 +11,7 @@ namespace casadi {
   extern "C" int CASADI_NLPSOL_CONOPT_EXPORT casadi_register_nlpsol_conopt(Nlpsol::Plugin* plugin) {
     plugin->creator = ConoptInterface::creator;
     plugin->name = "conopt";
-    plugin->doc = "CONOPT Interface";
+    plugin->doc = ConoptInterface::meta_doc.c_str();
     plugin->version = CASADI_VERSION;
     plugin->options = &ConoptInterface::options_;
     plugin->deserialize = &ConoptInterface::deserialize;

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -1,0 +1,476 @@
+#include "conopt_interface.hpp"
+#include "casadi/core/casadi_misc.hpp"
+#include "casadi/core/casadi_interrupt.hpp"
+#include <cmath>
+#include <cstring>
+#include <algorithm>
+
+namespace casadi {
+
+  extern "C" int casadi_register_nlpsol_conopt(Nlpsol::Plugin* plugin) {
+    plugin->creator = ConoptInterface::creator;
+    plugin->name = "conopt";
+    plugin->doc = "CONOPT Interface";
+    plugin->version = CASADI_VERSION;
+    plugin->options = &ConoptInterface::options_;
+    plugin->deserialize = &ConoptInterface::deserialize;
+    return 0;
+  }
+
+  extern "C" void casadi_load_nlpsol_conopt() {
+    Nlpsol::registerPlugin(casadi_register_nlpsol_conopt);
+  }
+
+  const Options ConoptInterface::options_ = {{&Nlpsol::options_}, {
+      {"exact_hessian", {OT_BOOL, "Provide exact Hessian to CONOPT"}},
+      {"conopt", {OT_DICT, "Options to be passed to CONOPT"}}
+  }};
+
+  ConoptInterface::ConoptInterface(const std::string& name, const Function& nlp)
+      : Nlpsol(name, nlp) {}
+
+  ConoptInterface::~ConoptInterface() { clear_mem(); }
+
+  void ConoptInterface::init(const Dict& opts) {
+    Nlpsol::init(opts);
+
+    // Extract native options
+    for (auto&& op : opts) {
+      if (op.first == "conopt") opts_ = op.second;
+    }
+
+    create_function("nlp_f", {"x", "p"}, {"f"});
+    create_function("nlp_g", {"x", "p"}, {"g"});
+    Function gradf_fcn = create_function("nlp_grad_f", {"x", "p"}, {"f", "grad:f:x"});
+    gradf_sp_ = gradf_fcn.sparsity_out(1);
+
+    Function jacg_fcn = create_function("nlp_jac_g", {"x", "p"}, {"g", "jac:g:x"});
+    jacg_sp_ = jacg_fcn.sparsity_out(1);
+
+    // Setup 2nd Order Info
+    exact_hessian_ = true;
+    if (opts.find("exact_hessian") != opts.end()) exact_hessian_ = opts.at("exact_hessian");
+
+    if (exact_hessian_) {
+      Function hl_fcn = create_function("nlp_hess_l", {"x", "p", "lam:f", "lam:g"},
+                                        {"tril:hess:gamma:x:x"}, {{"gamma", {"f", "g"}}});
+      hesslag_sp_ = hl_fcn.sparsity_out(0);
+      alloc_w(hesslag_sp_.nnz(), true);
+    }
+
+    jac_colsta_.resize(nx_ + 1, 0);
+    int numnz = 0;
+    std::vector<bool> has_gradf(nx_, false);
+    const casadi_int* f_row = gradf_sp_.row();
+    for (casadi_int k = 0; k < gradf_sp_.nnz(); ++k) has_gradf[f_row[k]] = true;
+
+    const casadi_int* g_colind = jacg_sp_.colind();
+    const casadi_int* g_row = jacg_sp_.row();
+
+    for (int c = 0; c < nx_; ++c) {
+      jac_colsta_[c] = numnz;
+      if (has_gradf[c]) {
+        jac_rowno_.push_back(0);
+        jac_nlflag_.push_back(1);
+        numnz++;
+      }
+      for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
+        jac_rowno_.push_back(g_row[el] + 1);
+        jac_nlflag_.push_back(1);
+        numnz++;
+      }
+    }
+    jac_colsta_[nx_] = numnz;
+
+    alloc_w(1, true);
+    alloc_w(gradf_sp_.nnz(), true);
+    alloc_w(ng_, true);
+    alloc_w(jacg_sp_.nnz(), true);
+  }
+
+  // --- Serialization & Deserialization --- //
+  ConoptInterface::ConoptInterface(DeserializingStream& s) : Nlpsol(s) {
+    int version = s.version("ConoptInterface", 1);
+    s.unpack("ConoptInterface::exact_hessian", exact_hessian_);
+    s.unpack("ConoptInterface::opts", opts_);
+    s.unpack("ConoptInterface::gradf_sp", gradf_sp_);
+    s.unpack("ConoptInterface::jacg_sp", jacg_sp_);
+    s.unpack("ConoptInterface::hesslag_sp", hesslag_sp_);
+    s.unpack("ConoptInterface::jac_colsta", jac_colsta_);
+    s.unpack("ConoptInterface::jac_rowno", jac_rowno_);
+    s.unpack("ConoptInterface::jac_nlflag", jac_nlflag_);
+  }
+
+  void ConoptInterface::serialize_body(SerializingStream &s) const {
+    Nlpsol::serialize_body(s);
+    s.version("ConoptInterface", 1);
+    s.pack("ConoptInterface::exact_hessian", exact_hessian_);
+    s.pack("ConoptInterface::opts", opts_);
+    s.pack("ConoptInterface::gradf_sp", gradf_sp_);
+    s.pack("ConoptInterface::jacg_sp", jacg_sp_);
+    s.pack("ConoptInterface::hesslag_sp", hesslag_sp_);
+    s.pack("ConoptInterface::jac_colsta", jac_colsta_);
+    s.pack("ConoptInterface::jac_rowno", jac_rowno_);
+    s.pack("ConoptInterface::jac_nlflag", jac_nlflag_);
+  }
+
+  ConoptMemory::ConoptMemory(const ConoptInterface& interface)
+      : self(interface), NlpsolMemory(), cntvect(nullptr), modsta(0), solsta(0),
+        iter(0), return_status("Unset"), success(0), cache_valid(false), current_option_idx(0) {}
+
+  ConoptMemory::~ConoptMemory() {
+    if (cntvect) COI_Free(&cntvect);
+  }
+
+  void ConoptInterface::free_mem(void* mem) const { delete static_cast<ConoptMemory*>(mem); }
+
+  int ConoptInterface::init_mem(void* mem) const {
+    if (Nlpsol::init_mem(mem)) return 1;
+    auto m = static_cast<ConoptMemory*>(mem);
+
+    m->cached_x.resize(nx_, 0.0);
+    m->cached_grad_f.resize(gradf_sp_.nnz(), 0.0);
+    m->cached_g.resize(ng_, 0.0);
+    m->cached_jac_g.resize(jacg_sp_.nnz(), 0.0);
+
+    COI_Create(&m->cntvect);
+
+    COIDEF_NumVar(m->cntvect, nx_);
+    COIDEF_NumCon(m->cntvect, ng_ + 1);
+    COIDEF_NumNz(m->cntvect, jac_rowno_.size());
+
+    COIDEF_ObjCon(m->cntvect, 0);
+    COIDEF_OptDir(m->cntvect, 1);
+
+    // Handle Options
+    m->custom_options.clear();
+    for (auto&& op : opts_) {
+        // Explictly catch C API options defined in conopt.h
+        if (op.first == "itlim") COIDEF_ItLim(m->cntvect, op.second.to_int());
+        else if (op.first == "errlim") COIDEF_ErrLim(m->cntvect, op.second.to_int());
+        else if (op.first == "reslim") COIDEF_ResLim(m->cntvect, op.second.to_double());
+        else if (op.first == "maxheap") COIDEF_MaxHeap(m->cntvect, op.second.to_double());
+        else {
+            // Push to custom options for the cb_option callback to feed dynamically
+            m->custom_options.push_back(op);
+        }
+    }
+    m->current_option_idx = 0;
+    COIDEF_Option(m->cntvect, &ConoptInterface::cb_option);
+    COIDEF_Progress(m->cntvect, &ConoptInterface::cb_progress);
+
+    // Register Callbacks
+    COIDEF_ReadMatrix(m->cntvect, &ConoptInterface::cb_read_matrix);
+    COIDEF_FDEvalIni(m->cntvect, &ConoptInterface::cb_fdevalini);
+    COIDEF_FDEval(m->cntvect, &ConoptInterface::cb_fd_eval);
+    COIDEF_FDEvalEnd(m->cntvect, &ConoptInterface::cb_fdevalend);
+
+    if (exact_hessian_) {
+        COIDEF_NumHess(m->cntvect, hesslag_sp_.nnz());
+        COIDEF_2DLagrSize(m->cntvect, &ConoptInterface::cb_2dlagrsize);
+        COIDEF_2DLagrStr(m->cntvect, &ConoptInterface::cb_2dlagrstr);
+        COIDEF_2DLagrVal(m->cntvect, &ConoptInterface::cb_2dlagrval);
+    }
+
+    COIDEF_Status(m->cntvect, &ConoptInterface::cb_status);
+    COIDEF_Solution(m->cntvect, &ConoptInterface::cb_solution);
+    COIDEF_Message(m->cntvect, &ConoptInterface::cb_message);
+    COIDEF_ErrMsg(m->cntvect, &ConoptInterface::cb_errmsg);
+    COIDEF_UsrMem(m->cntvect, m);
+
+    return 0;
+  }
+
+  void ConoptInterface::set_work(void* mem, const double**& arg, double**& res, casadi_int*& iw, double*& w) const {
+    Nlpsol::set_work(mem, arg, res, iw, w);
+  }
+
+  int ConoptInterface::solve(void* mem) const {
+    auto m = static_cast<ConoptMemory*>(mem);
+    m->cache_valid = false;
+    COI_Solve(m->cntvect);
+    m->success = (m->solsta == 1);
+    return 0;
+  }
+
+  Dict ConoptInterface::get_stats(void* mem) const {
+    Dict stats = Nlpsol::get_stats(mem);
+    auto m = static_cast<ConoptMemory*>(mem);
+    stats["return_status"] = m->return_status;
+    stats["modsta"] = m->modsta;
+    stats["solsta"] = m->solsta;
+    stats["iter_count"] = m->iter;
+    return stats;
+  }
+
+  // --- Dynamic Option Callback --- //
+  int COI_CALLCONV ConoptInterface::cb_option(int NCALL, double* RVAL, int* IVAL, int* LVAL, char* NAME, void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+
+    if (m->current_option_idx < m->custom_options.size()) {
+        auto& opt = m->custom_options[m->current_option_idx];
+
+        std::string name = opt.first;
+        if (name.length() > 8) name = name.substr(0, 8);
+        else name.append(8 - name.length(), ' ');
+        std::strncpy(NAME, name.c_str(), 8);
+
+        if (opt.second.is_double()) *RVAL = opt.second.to_double();
+        else if (opt.second.is_int()) *IVAL = opt.second.to_int();
+        else if (opt.second.is_bool()) *LVAL = opt.second.to_bool() ? 1 : 0;
+
+        m->current_option_idx++;
+    } else {
+        std::strncpy(NAME, "        ", 8);
+    }
+    return 0;
+  }
+
+  // --- Progress / Interrupt Callback --- //
+  int COI_CALLCONV ConoptInterface::cb_progress(int LEN_INT, const int INTX[], int LEN_RL, const double RL[], const double X[], void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+    const ConoptInterface& self = m->self;
+
+    if (!self.fcallback_.is_null()) {
+        int phase = (LEN_INT > 1) ? INTX[1] : -1;
+
+        double obj_val = 0.0;
+        if (LEN_RL > 1 && phase >= 3) {
+            obj_val = RL[1];
+        }
+
+        std::fill_n(m->arg, self.fcallback_.n_in(), nullptr);
+        m->arg[NLPSOL_X] = X;
+        m->arg[NLPSOL_F] = &obj_val;
+
+        std::fill_n(m->res, self.fcallback_.n_out(), nullptr);
+        double ret_double = 0;
+        m->res[0] = &ret_double;
+
+        try {
+            self.fcallback_(m->arg, m->res, m->iw, m->w, 0);
+            if (ret_double != 0.0) return 1;
+        } catch (KeyboardInterruptException& ex) {
+            return 1;
+        } catch (std::exception& ex) {
+            casadi_warning(std::string("intermediate_callback: ") + ex.what());
+            if (!self.iteration_callback_ignore_errors_) return 1;
+        }
+    }
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_read_matrix(double LOWER[], double CURR[], double UPPER[], int VSTA[], int TYPEX[], double RHS[], int ESTA[], int COLSTA[], int ROWNO[], double VALUE[], int NLFLAG[], int NUMVAR, int NUMCON, int NUMNZ, void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+    const ConoptInterface& self = m->self;
+
+    for(int i = 0; i < NUMVAR; ++i) {
+      if (!std::isinf(m->d_nlp.lbz[i])) LOWER[i] = m->d_nlp.lbz[i];
+      if (!std::isinf(m->d_nlp.ubz[i])) UPPER[i] = m->d_nlp.ubz[i];
+      CURR[i]  = m->d_nlp.z[i];
+    }
+
+    TYPEX[0] = 3;
+    RHS[0] = 0.0;
+
+    for(int i = 0; i < NUMCON - 1; ++i) {
+      double lbg = m->d_nlp.lbz[NUMVAR + i];
+      double ubg = m->d_nlp.ubz[NUMVAR + i];
+      int row_idx = i + 1;
+
+      if (lbg == ubg) {
+        TYPEX[row_idx] = 0;
+        RHS[row_idx] = lbg;
+      } else if (!std::isinf(lbg) && std::isinf(ubg)) {
+        TYPEX[row_idx] = 1;
+        RHS[row_idx] = lbg;
+      } else if (std::isinf(lbg) && !std::isinf(ubg)) {
+        TYPEX[row_idx] = 2;
+        RHS[row_idx] = ubg;
+      } else if (std::isinf(lbg) && std::isinf(ubg)) {
+        TYPEX[row_idx] = 3;
+        RHS[row_idx] = 0.0;
+      } else {
+        casadi_error("CONOPT does not accept range constraints.");
+      }
+    }
+
+    std::memcpy(COLSTA, self.jac_colsta_.data(), (NUMVAR + 1) * sizeof(int));
+    std::memcpy(ROWNO, self.jac_rowno_.data(), NUMNZ * sizeof(int));
+    std::memcpy(NLFLAG, self.jac_nlflag_.data(), NUMNZ * sizeof(int));
+
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_fdevalini(const double X[], const int ROWLIST[], int MODE, int LISTSIZE, int NUMTHREAD, int IGNERR, int* ERRCNT, int NUMVAR, void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+    const ConoptInterface& self = m->self;
+
+    std::memcpy(m->cached_x.data(), X, NUMVAR * sizeof(double));
+
+    try {
+        m->arg[0] = m->cached_x.data();
+        m->arg[1] = m->d_nlp.p;
+
+        m->res[0] = &m->cached_f;
+        m->res[1] = m->cached_grad_f.data();
+        self.calc_function(m, "nlp_grad_f");
+
+        m->res[0] = m->cached_g.data();
+        m->res[1] = m->cached_jac_g.data();
+        self.calc_function(m, "nlp_jac_g");
+
+        m->cache_valid = true;
+    } catch (...) {
+        *ERRCNT = 1;
+        m->cache_valid = false;
+    }
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_fd_eval(const double X[], double* G, double JAC[], int ROWNO, const int JACNUM[], int MODE, int IGNERR, int* ERRCNT, int NUMVAR, int NUMJAC, int THREAD, void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+    const ConoptInterface& self = m->self;
+
+    if (!m->cache_valid) {
+        *ERRCNT = 1;
+        return 0;
+    }
+
+    if (ROWNO == 0) {
+        if (MODE == 1 || MODE == 3) *G = m->cached_f;
+        if (MODE == 2 || MODE == 3) {
+            std::memset(JAC, 0, NUMVAR * sizeof(double));
+            const casadi_int* f_row = self.gradf_sp_.row();
+            for (casadi_int k = 0; k < self.gradf_sp_.nnz(); ++k) {
+                JAC[f_row[k]] = m->cached_grad_f[k];
+            }
+        }
+    }
+    else {
+        int g_rowno = ROWNO - 1;
+        if (MODE == 1 || MODE == 3) *G = m->cached_g[g_rowno];
+        if (MODE == 2 || MODE == 3) {
+            std::memset(JAC, 0, NUMVAR * sizeof(double));
+            const casadi_int* colind = self.jacg_sp_.colind();
+            const casadi_int* row = self.jacg_sp_.row();
+            for (int c = 0; c < NUMVAR; ++c) {
+                for (casadi_int el = colind[c]; el < colind[c+1]; ++el) {
+                    if (row[el] == g_rowno) {
+                        JAC[c] = m->cached_jac_g[el];
+                    }
+                }
+            }
+        }
+    }
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_fdevalend(int IGNERR, int* ERRCNT, void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+    m->cache_valid = false;
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_2dlagrsize(int* NODRV, int NUMVAR, int NUMCON, int* NHESS, int MAXHESS, void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+    const ConoptInterface& self = m->self;
+    *NHESS = self.hesslag_sp_.nnz();
+    if (*NHESS > MAXHESS) {
+        *NODRV = 1;
+    }
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_2dlagrstr(int HSRW[], int HSCL[], int* NODRV, int NUMVAR, int NUMCON, int NHESS, void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+    const ConoptInterface& self = m->self;
+    const casadi_int* colind = self.hesslag_sp_.colind();
+    const casadi_int* row = self.hesslag_sp_.row();
+
+    int idx = 0;
+    for (int c = 0; c < NUMVAR; ++c) {
+        for (casadi_int el = colind[c]; el < colind[c+1]; ++el) {
+            HSRW[idx] = row[el];
+            HSCL[idx] = c;
+            idx++;
+        }
+    }
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_2dlagrval(const double X[], const double U[], const int HSRW[], const int HSCL[], double HSVL[], int* NODRV, int NUMVAR, int NUMCON, int NHESS, void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+    const ConoptInterface& self = m->self;
+
+    double obj_factor = U[0];
+    const double* lam_g = &U[1];
+
+    m->arg[0] = X;
+    m->arg[1] = m->d_nlp.p;
+    m->arg[2] = &obj_factor;
+    m->arg[3] = lam_g;
+    m->res[0] = HSVL;
+
+    try {
+        self.calc_function(m, "nlp_hess_l");
+    } catch (...) {
+        *NODRV = 1;
+    }
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_status(int MODSTA, int SOLSTA, int ITER, double OBJVAL, void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+    m->modsta = MODSTA;
+    m->solsta = SOLSTA;
+    m->iter = ITER;
+    m->d_nlp.objective = OBJVAL;
+
+    if (SOLSTA == 1) m->return_status = "Optimal";
+    else if (SOLSTA >= 6 && SOLSTA <= 11) m->return_status = "No Solution (Major Error)";
+    else m->return_status = "Suboptimal/Infeasible";
+
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_solution(const double XVAL[], const double XMAR[], const int XBAS[], const int XSTA[], const double YVAL[], const double YMAR[], const int YBAS[], const int YSTA[], int NUMVAR, int NUMCON, void* USRMEM) {
+    auto m = static_cast<ConoptMemory*>(USRMEM);
+
+    casadi_copy(XVAL, NUMVAR, m->d_nlp.z);
+    casadi_copy(XMAR, NUMVAR, m->d_nlp.lam);
+    casadi_copy(YVAL + 1, NUMCON - 1, m->d_nlp.z + NUMVAR);
+    casadi_copy(YMAR + 1, NUMCON - 1, m->d_nlp.lam + NUMVAR);
+
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_message(int SMSG, int DMSG, int NMSG, char* MSGV[], void* USRMEM) {
+    for (int i = 0; i < SMSG; ++i) {
+        if (MSGV[i] != nullptr) {
+            casadi::uout() << MSGV[i] << std::endl;
+        }
+    }
+    return 0;
+  }
+
+  int COI_CALLCONV ConoptInterface::cb_errmsg(int ROWNO, int COLNO, int POSNO, const char* MSG, void* USRMEM) {
+    if (MSG == nullptr) return 0;
+
+    std::string prefix = "CONOPT Error: ";
+    if (COLNO == -1 && ROWNO >= 0) {
+        prefix += "Row " + std::to_string(ROWNO) + " - ";
+    } else if (ROWNO == -1 && COLNO >= 0) {
+        prefix += "Column " + std::to_string(COLNO) + " - ";
+    } else if (ROWNO >= 0 && COLNO >= 0) {
+        if (POSNO >= 0) {
+            prefix += "Jacobian Pos " + std::to_string(POSNO) + " (Row " + std::to_string(ROWNO) + ", Col " + std::to_string(COLNO) + ") - ";
+        } else if (POSNO == -1) {
+            prefix += "Pair (Row " + std::to_string(ROWNO) + ", Col " + std::to_string(COLNO) + ") - ";
+        }
+    }
+
+    casadi::uerr() << prefix << MSG << std::endl;
+    return 0;
+  }
+}

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -1,3 +1,27 @@
+/*
+ *    This file is part of CasADi.
+ *
+ *    CasADi -- A symbolic framework for dynamic optimization.
+ *    Copyright (C) 2010-2023 Joel Andersson, Joris Gillis, Moritz Diehl,
+ *                            KU Leuven. All rights reserved.
+ *    Copyright (C) 2011-2014 Greg Horn
+ *
+ *    CasADi is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation; either
+ *    version 3 of the License, or (at your option) any later version.
+ *
+ *    CasADi is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public
+ *    License along with CasADi; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
 #include "conopt_interface.hpp"
 #include "casadi/core/casadi_misc.hpp"
 #include "casadi/core/casadi_interrupt.hpp"
@@ -24,10 +48,15 @@ namespace casadi {
 
   const Options ConoptInterface::options_ = {{&Nlpsol::options_}, {
       {"exact_hessian", {OT_BOOL, "Provide exact Hessian to CONOPT"}},
-      {"warm_start", {OT_BOOL, "Warm-start CONOPT using multipliers from a prior solve to infer basis status (IniStat=2)"}},
+      {"warm_start", {OT_BOOL,
+        "Warm-start CONOPT using multipliers from a prior solve to infer "
+        "basis status (IniStat=2)"}},
       {"conopt", {OT_DICT, "Options to be passed to CONOPT"}},
-      {"optfile", {OT_STRING, "Path to a CONOPT option file (for string-valued CR-cells such as Algorithm)"}},
-      {"debug", {OT_BOOL, "Print debug output: constraint values at each FDEval, solution vector, and option echo"}}
+      {"optfile", {OT_STRING,
+        "Path to a CONOPT option file (for string-valued CR-cells such as Algorithm)"}},
+      {"debug", {OT_BOOL,
+        "Print debug output: constraint values at each FDEval, solution vector, "
+        "and option echo"}}
   }};
 
   ConoptInterface::ConoptInterface(const std::string& name, const Function& nlp)
@@ -101,7 +130,8 @@ namespace casadi {
     const casadi_int* g_colind = jacg_sp_.colind();
     const casadi_int* g_row = jacg_sp_.row();
 
-    // Build row-indexed CSR structure over nonlinear entries for fast Jacobian scatter in cb_fd_eval
+    // Build row-indexed CSR structure over nonlinear entries for fast
+    // Jacobian scatter in cb_fd_eval
     casadi_int nnz_g = jacg_sp_.nnz();
     jacg_rowstart_.assign(ng_ + 1, 0);
     for (casadi_int el = 0; el < nnz_g; ++el)
@@ -114,11 +144,11 @@ namespace casadi {
     for (int c = 0; c < nx_; ++c) {
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
         if (!jacg_nlflag_[el]) continue;
-        int r = (int)g_row[el];
+        int r = static_cast<int>(g_row[el]);
         casadi_assert(fill_pos[r] < jacg_rowstart_[r + 1] - jacg_rowstart_[r],
                       "CSR fill overflow for row r - count/fill pass mismatch in jacg_rowstart_");
         int pos = jacg_rowstart_[r] + fill_pos[r]++;
-        jacg_nzidx_[pos] = (int)el;
+        jacg_nzidx_[pos] = static_cast<int>(el);
         jacg_col_[pos]   = c;
       }
     }
@@ -180,11 +210,11 @@ namespace casadi {
     for (int c = 0; c < nx_; ++c)
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
         if (!jacg_nlflag_[el]) continue;
-        int r = (int)g_row[el];
+        int r = static_cast<int>(g_row[el]);
         casadi_assert(fill_pos[r] < jacg_rowstart_[r + 1] - jacg_rowstart_[r],
                       "CSR fill overflow for row r - count/fill pass mismatch in jacg_rowstart_");
         int pos = jacg_rowstart_[r] + fill_pos[r]++;
-        jacg_nzidx_[pos] = (int)el;
+        jacg_nzidx_[pos] = static_cast<int>(el);
         jacg_col_[pos]   = c;
       }
   }
@@ -301,8 +331,24 @@ namespace casadi {
     return 0;
   }
 
-  void ConoptInterface::set_work(void* mem, const double**& arg, double**& res, casadi_int*& iw, double*& w) const {
+  void ConoptInterface::set_work(void* mem, const double**& arg, double**& res,
+                                  casadi_int*& iw, double*& w) const {
     Nlpsol::set_work(mem, arg, res, iw, w);
+  }
+
+  // conopt_to_casadi/conopt_type/conopt_rhs always grow in lockstep, so a single
+  // capacity check (on conopt_to_casadi) is enough to decide whether to grow all
+  // three. Growth is by 0.25 of the CasADi rows not yet processed, rather than
+  // jumping straight to the worst-case (all-range) size.
+  void ConoptInterface::ensure_row_capacity(ConoptMemory* m, casadi_int remaining_rows) const {
+    if (m->conopt_to_casadi.size() == m->conopt_to_casadi.capacity()) {
+      casadi_int growth = std::max<casadi_int>(
+          std::min<casadi_int>(remaining_rows, 10), remaining_rows / 4);
+      casadi_int new_cap = m->conopt_to_casadi.capacity() + growth;
+      m->conopt_to_casadi.reserve(new_cap);
+      m->conopt_type.reserve(new_cap);
+      m->conopt_rhs.reserve(new_cap);
+    }
   }
 
   int ConoptInterface::solve(void* mem) const {
@@ -331,20 +377,6 @@ namespace casadi {
     // (so that gradf_const_vals is populated before we check for non-zero linear entries).
     casadi_int numnz = (casadi_int)jacg_sp_.nnz();
 
-    // conopt_to_casadi/conopt_type/conopt_rhs always grow in lockstep, so a single
-    // capacity check (on conopt_to_casadi) is enough to decide whether to grow all
-    // three. Growth is by 0.25 of the CasADi rows not yet processed, rather than
-    // jumping straight to the worst-case (all-range) size.
-    auto ensure_row_capacity = [m](casadi_int remaining_rows) {
-      if (m->conopt_to_casadi.size() == m->conopt_to_casadi.capacity()) {
-        casadi_int new_cap = m->conopt_to_casadi.capacity() +
-                              std::max<casadi_int>(std::min<casadi_int>(remaining_rows, 10), remaining_rows / 4);
-        m->conopt_to_casadi.reserve(new_cap);
-        m->conopt_type.reserve(new_cap);
-        m->conopt_rhs.reserve(new_cap);
-      }
-    };
-
     for (casadi_int i = 0; i < ng_; ++i) {
       double lbg = m->d_nlp.lbz[nx_ + i];
       double ubg = m->d_nlp.ubz[nx_ + i];
@@ -352,9 +384,9 @@ namespace casadi {
 
       // CONOPT row 0 is reserved for the objective, so constraint rows start at 1
       // (arrays are still plain 0-based C arrays; only the row *numbering* is offset).
-      m->casadi_to_conopt_lb_row[i] = (int)(ng_expanded + 1);
-      ensure_row_capacity(ng_ - i);
-      m->conopt_to_casadi.push_back((int)i);
+      m->casadi_to_conopt_lb_row[i] = static_cast<int>(ng_expanded + 1);
+      ensure_row_capacity(m, ng_ - i);
+      m->conopt_to_casadi.push_back(static_cast<int>(i));
       if (lbg == ubg) {
         m->conopt_type.push_back(ConoptRowType::Equality);  m->conopt_rhs.push_back(lbg);
       } else if (!std::isinf(lbg) && std::isinf(ubg)) {
@@ -364,21 +396,24 @@ namespace casadi {
       } else if (std::isinf(lbg) && std::isinf(ubg)) {
         m->conopt_type.push_back(ConoptRowType::Free);  m->conopt_rhs.push_back(0.0);
       } else {
-        m->conopt_type.push_back(ConoptRowType::GreaterEqual);  m->conopt_rhs.push_back(lbg);  // range: >= row
+        // range: >= row
+        m->conopt_type.push_back(ConoptRowType::GreaterEqual);
+        m->conopt_rhs.push_back(lbg);
       }
       ng_expanded++;
 
       if (is_range) {
-        m->casadi_to_conopt_ub_row[i] = (int)(ng_expanded + 1);
-        ensure_row_capacity(ng_ - i);
-        m->conopt_to_casadi.push_back((int)i);
-        m->conopt_type.push_back(ConoptRowType::LessEqual);  m->conopt_rhs.push_back(ubg);  // <= row
+        m->casadi_to_conopt_ub_row[i] = static_cast<int>(ng_expanded + 1);
+        ensure_row_capacity(m, ng_ - i);
+        m->conopt_to_casadi.push_back(static_cast<int>(i)); // <= row
+        m->conopt_type.push_back(ConoptRowType::LessEqual);
+        m->conopt_rhs.push_back(ubg);
         ng_expanded++;
         numnz += m->row_nnz[i];
       }
     }
     casadi_assert(ng_expanded <= std::numeric_limits<int>::max(), "ng_expanded overflows int");
-    m->ng_expanded = (int)ng_expanded;
+    m->ng_expanded = static_cast<int>(ng_expanded);
 
     // Evaluate Jacobian at the initial point to obtain values for constant entries
     if (has_linear_jac_) {
@@ -476,7 +511,7 @@ namespace casadi {
     for (casadi_int c = 0; c < nx_; ++c) {
       for (casadi_int el = g_colind_s[c]; el < g_colind_s[c+1]; ++el) {
         if (jacg_nlflag_[el]) {
-          int ci = (int)g_row_s[el];
+          int ci = static_cast<int>(g_row_s[el]);
           num_nl_nz += (m->casadi_to_conopt_ub_row[ci] >= 0) ? 2 : 1;
         }
       }
@@ -498,11 +533,11 @@ namespace casadi {
       numnz += numnz_f;
     }
     casadi_assert(numnz <= std::numeric_limits<int>::max(), "numnz overflows int");
-    m->numnz_expanded = (int)numnz;
+    m->numnz_expanded = static_cast<int>(numnz);
 
-    COIDEF_NumCon(m->cntvect, (int)(ng_expanded + 1));
-    COIDEF_NumNz(m->cntvect, (int)numnz);
-    COIDEF_NumNlNz(m->cntvect, (int)num_nl_nz);
+    COIDEF_NumCon(m->cntvect, static_cast<int>(ng_expanded + 1));
+    COIDEF_NumNz(m->cntvect, static_cast<int>(numnz));
+    COIDEF_NumNlNz(m->cntvect, static_cast<int>(num_nl_nz));
 
     int ret = COI_Solve(m->cntvect);
 
@@ -549,10 +584,11 @@ namespace casadi {
   }
 
   // --- Dynamic Option Callback --- //
-  int COI_CALLCONV ConoptInterface::cb_option(int NCALL, double* RVAL, int* IVAL, int* LVAL, char* NAME, void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_option(int NCALL, double* RVAL, int* IVAL,
+                                               int* LVAL, char* NAME, void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
 
-    if (NCALL >= (int)m->custom_options.size()) {
+    if (NCALL >= static_cast<int>(m->custom_options.size())) {
         NAME[0] = '\0';
         return 0;
     }
@@ -562,15 +598,19 @@ namespace casadi {
 
     if (opt.second.is_double()) {
         *RVAL = opt.second.to_double();
-        if (m->self.debug_) casadi::uout() << "CONOPT option: " << opt.first << " = " << *RVAL << std::endl;
+        if (m->self.debug_)
+            casadi::uout() << "CONOPT option: " << opt.first << " = " << *RVAL << std::endl;
     } else if (opt.second.is_int()) {
         *IVAL = opt.second.to_int();
-        if (m->self.debug_) casadi::uout() << "CONOPT option: " << opt.first << " = " << *IVAL << std::endl;
+        if (m->self.debug_)
+            casadi::uout() << "CONOPT option: " << opt.first << " = " << *IVAL << std::endl;
     } else if (opt.second.is_bool()) {
         *LVAL = opt.second.to_bool() ? 1 : 0;
-        if (m->self.debug_) casadi::uout() << "CONOPT option: " << opt.first << " = " << (opt.second.to_bool() ? "true" : "false") << std::endl;
-    }
-    else if (opt.second.is_string()) {
+        if (m->self.debug_) {
+            casadi::uout() << "CONOPT option: " << opt.first << " = "
+                           << (opt.second.to_bool() ? "true" : "false") << std::endl;
+        }
+    } else if (opt.second.is_string()) {
         // init_mem filters out all string options before they enter custom_options
         // (with a casadi_warning directing the user to 'optfile'). Reaching this
         // branch means custom_options was populated externally in a way that
@@ -594,7 +634,9 @@ namespace casadi {
   }
 
   // --- Progress / Interrupt Callback --- //
-  int COI_CALLCONV ConoptInterface::cb_progress(int LEN_INT, const int INTX[], int LEN_RL, const double RL[], const double X[], void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_progress(int LEN_INT, const int INTX[], int LEN_RL,
+                                                 const double RL[], const double X[],
+                                                 void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
@@ -627,7 +669,12 @@ namespace casadi {
     return 0;
   }
 
-  int COI_CALLCONV ConoptInterface::cb_read_matrix(double LOWER[], double CURR[], double UPPER[], int VSTA[], int TYPEX[], double RHS[], int ESTA[], int COLSTA[], int ROWNO[], double VALUE[], int NLFLAG[], int NUMVAR, int NUMCON, int NUMNZ, void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_read_matrix(double LOWER[], double CURR[],
+                                                    double UPPER[], int VSTA[], int TYPEX[],
+                                                    double RHS[], int ESTA[], int COLSTA[],
+                                                    int ROWNO[], double VALUE[],
+                                                    int NLFLAG[], int NUMVAR, int NUMCON,
+                                                    int NUMNZ, void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
@@ -685,7 +732,8 @@ namespace casadi {
 
         for (int r = 0; r < m->ng_expanded; ++r) {
           int ci        = m->conopt_to_casadi[r];
-          double lam_ci = lam[NUMVAR + ci];  // this constraint's multiplier, same sign logic as above
+          // this constraint's multiplier, same sign logic as above
+          double lam_ci = lam[NUMVAR + ci];
           int row1      = m->casadi_to_conopt_lb_row[ci];
           int row2      = m->casadi_to_conopt_ub_row[ci];
           if (r + 1 == row1) {
@@ -695,7 +743,8 @@ namespace casadi {
             } else if (ctype == ConoptRowType::GreaterEqual) {  // >= row: active when lam_ci < 0
               ESTA[r + 1] = static_cast<int>(
                   (lam_ci < 0.0) ? ConoptBasisStatus::AtLower : ConoptBasisStatus::Basic);
-            } else if (ctype == ConoptRowType::LessEqual) {  // <= row (pure <= stored as lb_row): active when lam_ci > 0
+            } else if (ctype == ConoptRowType::LessEqual) {
+              // <= row (pure <= stored as lb_row): active when lam_ci > 0
               ESTA[r + 1] = static_cast<int>(
                   (lam_ci > 0.0) ? ConoptBasisStatus::AtUpper : ConoptBasisStatus::Basic);
             } else {                        // free row: superbasic
@@ -739,7 +788,7 @@ namespace casadi {
       // Constraint-Jacobian entries in column c; duplicated onto the ub row too
       // when this CasADi row was split into a range constraint by solve().
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
-        int ci = (int)g_row[el];
+        int ci = static_cast<int>(g_row[el]);
         int nlflag = self.jacg_nlflag_[el];
         ROWNO[nz]  = m->casadi_to_conopt_lb_row[ci];
         NLFLAG[nz] = nlflag;
@@ -762,12 +811,16 @@ namespace casadi {
     return 0;
   }
 
-  int COI_CALLCONV ConoptInterface::cb_fdevalini(const double X[], const int ROWLIST[], int MODE, int LISTSIZE, int NUMTHREAD, int IGNERR, int* ERRCNT, int NUMVAR, void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_fdevalini(const double X[], const int ROWLIST[],
+                                                  int MODE, int LISTSIZE, int NUMTHREAD,
+                                                  int IGNERR, int* ERRCNT, int NUMVAR,
+                                                  void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
     casadi_assert(NUMVAR == self.nx_, "cb_fdevalini: NUMVAR != nx_");
-    casadi_assert((size_t)NUMVAR == m->cached_x.size(), "cb_fdevalini: NUMVAR != cached_x size");
+    casadi_assert(static_cast<size_t>(NUMVAR) == m->cached_x.size(),
+                  "cb_fdevalini: NUMVAR != cached_x size");
 
     std::memcpy(m->cached_x.data(), X, NUMVAR * sizeof(double));
 
@@ -832,7 +885,10 @@ namespace casadi {
     return 0;
   }
 
-  int COI_CALLCONV ConoptInterface::cb_fd_eval(const double X[], double* G, double JAC[], int ROWNO, const int JACNUM[], int MODE, int IGNERR, int* ERRCNT, int NUMVAR, int NUMJAC, int THREAD, void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_fd_eval(const double X[], double* G, double JAC[],
+                                                int ROWNO, const int JACNUM[], int MODE,
+                                                int IGNERR, int* ERRCNT, int NUMVAR,
+                                                int NUMJAC, int THREAD, void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
@@ -857,7 +913,8 @@ namespace casadi {
                 if (self.gradf_nlflag_[k]) {
                     JAC[f_row[k]] = m->cached_grad_f[k];
                     if (self.debug_)
-                        casadi::uout() << "  df/dx[" << f_row[k] << "] = " << m->cached_grad_f[k] << "\n";
+                        casadi::uout() << "  df/dx[" << f_row[k] << "] = "
+                                       << m->cached_grad_f[k] << "\n";
                 }
             }
         }
@@ -876,7 +933,8 @@ namespace casadi {
                 if (ctype == ConoptRowType::Free)
                     casadi::uout() << "  g[" << ci << "](x) = " << *G << " (free)\n";
                 else
-                    casadi::uout() << "  g[" << ci << "](x) = " << *G << " " << rel << " " << rhs << "\n";
+                    casadi::uout() << "  g[" << ci << "](x) = " << *G << " "
+                                   << rel << " " << rhs << "\n";
             }
         }
         if (MODE == 2 || MODE == 3) {
@@ -907,7 +965,9 @@ namespace casadi {
     return 0;
   }
 
-  int COI_CALLCONV ConoptInterface::cb_2dlagrstr(int HSRW[], int HSCL[], int* NODRV, int NUMVAR, int NUMCON, int NHESS, void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_2dlagrstr(int HSRW[], int HSCL[], int* NODRV,
+                                                  int NUMVAR, int NUMCON, int NHESS,
+                                                  void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
     const casadi_int* colind = self.hesslag_sp_.colind();
@@ -926,7 +986,10 @@ namespace casadi {
     return 0;
   }
 
-  int COI_CALLCONV ConoptInterface::cb_2dlagrval(const double X[], const double U[], const int HSRW[], const int HSCL[], double HSVL[], int* NODRV, int NUMVAR, int NUMCON, int NHESS, void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_2dlagrval(const double X[], const double U[],
+                                                  const int HSRW[], const int HSCL[],
+                                                  double HSVL[], int* NODRV, int NUMVAR,
+                                                  int NUMCON, int NHESS, void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     const ConoptInterface& self = m->self;
 
@@ -971,7 +1034,8 @@ namespace casadi {
     return 0;
   }
 
-  int COI_CALLCONV ConoptInterface::cb_status(int MODSTA, int SOLSTA, int ITER, double OBJVAL, void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_status(int MODSTA, int SOLSTA, int ITER,
+                                               double OBJVAL, void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
     m->modsta = static_cast<ConoptModelStatus>(MODSTA);
     m->solsta = static_cast<ConoptSolverStatus>(SOLSTA);
@@ -994,25 +1058,41 @@ namespace casadi {
 
     const char* solsta_str;
     switch (m->solsta) {
-      case ConoptSolverStatus::NormalCompletion:     solsta_str = "Normal completion";                   break;
-      case ConoptSolverStatus::IterationLimit:       solsta_str = "Iteration limit";                     break;
-      case ConoptSolverStatus::TimeLimit:            solsta_str = "Time limit";                          break;
-      case ConoptSolverStatus::TerminatedBySolver:   solsta_str = "Terminated by solver";                break;
-      case ConoptSolverStatus::EvalErrorLimit:       solsta_str = "Evaluation error limit";              break;
-      case ConoptSolverStatus::UserInterrupt:        solsta_str = "User interrupt";                      break;
-      case ConoptSolverStatus::SetupFailure:         solsta_str = "Setup failure";                       break;
-      case ConoptSolverStatus::MajorSolverError:     solsta_str = "Major solver error";                  break;
-      case ConoptSolverStatus::MajorSolverErrorFeas: solsta_str = "Major solver error (feasible point)"; break;
-      case ConoptSolverStatus::SystemError:          solsta_str = "System error";                        break;
-      case ConoptSolverStatus::QuickModeTermination: solsta_str = "Quick Mode termination";              break;
-      default:                                       solsta_str = "Unknown solver status";               break;
+      case ConoptSolverStatus::NormalCompletion:
+        solsta_str = "Normal completion";                   break;
+      case ConoptSolverStatus::IterationLimit:
+        solsta_str = "Iteration limit";                     break;
+      case ConoptSolverStatus::TimeLimit:
+        solsta_str = "Time limit";                          break;
+      case ConoptSolverStatus::TerminatedBySolver:
+        solsta_str = "Terminated by solver";                break;
+      case ConoptSolverStatus::EvalErrorLimit:
+        solsta_str = "Evaluation error limit";              break;
+      case ConoptSolverStatus::UserInterrupt:
+        solsta_str = "User interrupt";                      break;
+      case ConoptSolverStatus::SetupFailure:
+        solsta_str = "Setup failure";                       break;
+      case ConoptSolverStatus::MajorSolverError:
+        solsta_str = "Major solver error";                  break;
+      case ConoptSolverStatus::MajorSolverErrorFeas:
+        solsta_str = "Major solver error (feasible point)"; break;
+      case ConoptSolverStatus::SystemError:
+        solsta_str = "System error";                        break;
+      case ConoptSolverStatus::QuickModeTermination:
+        solsta_str = "Quick Mode termination";              break;
+      default:
+        solsta_str = "Unknown solver status";               break;
     }
 
     m->return_status = std::string(modsta_str) + " / " + std::string(solsta_str);
     return 0;
   }
 
-  int COI_CALLCONV ConoptInterface::cb_solution(const double XVAL[], const double XMAR[], const int XBAS[], const int XSTA[], const double YVAL[], const double YMAR[], const int YBAS[], const int YSTA[], int NUMVAR, int NUMCON, void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_solution(const double XVAL[], const double XMAR[],
+                                                 const int XBAS[], const int XSTA[],
+                                                 const double YVAL[], const double YMAR[],
+                                                 const int YBAS[], const int YSTA[],
+                                                 int NUMVAR, int NUMCON, void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
 
     casadi_copy(XVAL, NUMVAR, m->d_nlp.z);
@@ -1045,7 +1125,8 @@ namespace casadi {
     return 0;
   }
 
-  int COI_CALLCONV ConoptInterface::cb_message(int SMSG, int DMSG, int NMSG, char* MSGV[], void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_message(int SMSG, int DMSG, int NMSG, char* MSGV[],
+                                                void* USRMEM) {
     auto m = static_cast<ConoptMemory*>(USRMEM);
 
     int message_length = SMSG;
@@ -1059,7 +1140,8 @@ namespace casadi {
     return 0;
   }
 
-  int COI_CALLCONV ConoptInterface::cb_errmsg(int ROWNO, int COLNO, int POSNO, const char* MSG, void* USRMEM) {
+  int COI_CALLCONV ConoptInterface::cb_errmsg(int ROWNO, int COLNO, int POSNO,
+                                               const char* MSG, void* USRMEM) {
     if (MSG == nullptr) return 0;
 
     std::string prefix = "CONOPT Error: ";
@@ -1069,13 +1151,15 @@ namespace casadi {
         prefix += "Column " + std::to_string(COLNO) + " - ";
     } else if (ROWNO >= 0 && COLNO >= 0) {
         if (POSNO >= 0) {
-            prefix += "Jacobian Pos " + std::to_string(POSNO) + " (Row " + std::to_string(ROWNO) + ", Col " + std::to_string(COLNO) + ") - ";
+            prefix += "Jacobian Pos " + std::to_string(POSNO) + " (Row " +
+                      std::to_string(ROWNO) + ", Col " + std::to_string(COLNO) + ") - ";
         } else if (POSNO == -1) {
-            prefix += "Pair (Row " + std::to_string(ROWNO) + ", Col " + std::to_string(COLNO) + ") - ";
+            prefix += "Pair (Row " + std::to_string(ROWNO) + ", Col " +
+                      std::to_string(COLNO) + ") - ";
         }
     }
 
     casadi::uerr() << prefix << MSG << std::endl;
     return 0;
   }
-}
+}  // namespace casadi

--- a/casadi/interfaces/conopt/conopt_interface.cpp
+++ b/casadi/interfaces/conopt/conopt_interface.cpp
@@ -47,6 +47,19 @@ namespace casadi {
     Function jacg_fcn = create_function("nlp_jac_g", {"x", "p"}, {"g", "jac:g:x"});
     jacg_sp_ = jacg_fcn.sparsity_out(1);
 
+    // Detect linear (constant) Jacobian entries using second-order sparsity:
+    // d(jac:g:x_compact)/dx has shape (nnz_g, nx_); if row k is empty,
+    // the k-th Jacobian nonzero is constant in x (linear entry).
+    {
+      Sparsity djac_dx = jacg_fcn.sparsity_jac(0, 1, true);
+      jacg_nlflag_.assign(jacg_sp_.nnz(), 0);
+      const casadi_int* dj_row = djac_dx.row();
+      for (casadi_int el = 0; el < djac_dx.nnz(); ++el)
+        jacg_nlflag_[dj_row[el]] = 1;
+      has_linear_jac_ = std::any_of(jacg_nlflag_.begin(), jacg_nlflag_.end(),
+                                     [](int f) { return f == 0; });
+    }
+
     // Setup 2nd Order Info
     exact_hessian_ = true;
     if (opts.find("exact_hessian") != opts.end()) exact_hessian_ = opts.at("exact_hessian");
@@ -125,6 +138,17 @@ namespace casadi {
         jacg_col_[p] = c;
         jacg_nzidx_[p] = (int)el;
       }
+
+    // Recompute linearity flags (not serialized; derived from the function)
+    {
+      Sparsity djac_dx = get_function("nlp_jac_g").sparsity_jac(0, 1, true);
+      jacg_nlflag_.assign(jacg_sp_.nnz(), 0);
+      const casadi_int* dj_row = djac_dx.row();
+      for (casadi_int el = 0; el < djac_dx.nnz(); ++el)
+        jacg_nlflag_[dj_row[el]] = 1;
+      has_linear_jac_ = std::any_of(jacg_nlflag_.begin(), jacg_nlflag_.end(),
+                                     [](int f) { return f == 0; });
+    }
   }
 
   void ConoptInterface::serialize_body(SerializingStream &s) const {
@@ -160,6 +184,8 @@ namespace casadi {
     m->cached_jac_g.resize(jacg_sp_.nnz(), 0.0);
     m->casadi_to_conopt_lb_row.resize(ng_);
     m->casadi_to_conopt_ub_row.assign(ng_, -1);
+    if (has_linear_jac_)
+      m->const_jac_vals.resize(jacg_sp_.nnz(), 0.0);
 
     COI_Create(&m->cntvect);
 
@@ -259,9 +285,35 @@ namespace casadi {
     m->ng_expanded    = ng_expanded;
     m->numnz_expanded = numnz;
 
+    // Evaluate Jacobian at the initial point to obtain values for constant entries
+    if (has_linear_jac_) {
+      m->arg[0] = m->d_nlp.z;
+      m->arg[1] = m->d_nlp.p;
+      m->res[0] = m->cached_g.data();
+      m->res[1] = m->const_jac_vals.data();
+      try {
+        calc_function(m, "nlp_jac_g");
+      } catch (...) {
+        std::fill(m->const_jac_vals.begin(), m->const_jac_vals.end(), 0.0);
+      }
+    }
+
+    // Count nonlinear NZ: all objective gradient entries + nonlinear constraint entries
+    const casadi_int* g_colind_s = jacg_sp_.colind();
+    const casadi_int* g_row_s    = jacg_sp_.row();
+    int num_nl_nz = (int)gradf_sp_.nnz();
+    for (casadi_int c = 0; c < nx_; ++c) {
+      for (casadi_int el = g_colind_s[c]; el < g_colind_s[c+1]; ++el) {
+        if (jacg_nlflag_[el]) {
+          int ci = (int)g_row_s[el];
+          num_nl_nz += (m->casadi_to_conopt_ub_row[ci] >= 0) ? 2 : 1;
+        }
+      }
+    }
+
     COIDEF_NumCon(m->cntvect, ng_expanded + 1);
     COIDEF_NumNz(m->cntvect, numnz);
-    COIDEF_NumNlNz(m->cntvect, numnz);
+    COIDEF_NumNlNz(m->cntvect, num_nl_nz);
 
     int ret = COI_Solve(m->cntvect);
     if (ret != 0) {
@@ -383,12 +435,15 @@ namespace casadi {
       }
       for (casadi_int el = g_colind[c]; el < g_colind[c+1]; ++el) {
         int ci = (int)g_row[el];
+        int nlflag = self.jacg_nlflag_[el];
         ROWNO[nz]  = m->casadi_to_conopt_lb_row[ci];
-        NLFLAG[nz] = 1;
+        NLFLAG[nz] = nlflag;
+        if (nlflag == 0) VALUE[nz] = m->const_jac_vals[el];
         nz++;
         if (m->casadi_to_conopt_ub_row[ci] >= 0) {
           ROWNO[nz]  = m->casadi_to_conopt_ub_row[ci];
-          NLFLAG[nz] = 1;
+          NLFLAG[nz] = nlflag;
+          if (nlflag == 0) VALUE[nz] = m->const_jac_vals[el];
           nz++;
         }
       }

--- a/casadi/interfaces/conopt/conopt_interface.h
+++ b/casadi/interfaces/conopt/conopt_interface.h
@@ -1,0 +1,104 @@
+#ifndef CASADI_CONOPT_INTERFACE_HPP
+#define CASADI_CONOPT_INTERFACE_HPP
+
+#include "casadi/core/nlpsol_impl.hpp"
+#include <conopt.h>
+#include <vector>
+#include <string>
+#include <utility>
+
+namespace casadi {
+  class ConoptInterface;
+
+  struct ConoptMemory : public NlpsolMemory {
+    const ConoptInterface& self;
+    coiHandle_t cntvect;
+
+    int modsta;
+    int solsta;
+    int iter;
+    const char* return_status;
+    int success;
+
+    // Caching state for the evaluation block
+    std::vector<double> cached_x;
+    double cached_f;
+    std::vector<double> cached_grad_f;
+    std::vector<double> cached_g;
+    std::vector<double> cached_jac_g;
+    bool cache_valid;
+
+    // Options handling
+    std::vector<std::pair<std::string, GenericType>> custom_options;
+    size_t current_option_idx;
+
+    ConoptMemory(const ConoptInterface& interface);
+    ~ConoptMemory();
+  };
+
+  class ConoptInterface : public Nlpsol {
+  public:
+    explicit ConoptInterface(const std::string& name, const Function& nlp);
+    ~ConoptInterface() override;
+
+    const char* plugin_name() const override { return "conopt"; }
+    std::string class_name() const override { return "ConoptInterface"; }
+
+    static Nlpsol* creator(const std::string& name, const Function& nlp) {
+      return new ConoptInterface(name, nlp);
+    }
+
+    static const Options options_;
+    const Options& get_options() const override { return options_; }
+
+    void init(const Dict& opts) override;
+    void* alloc_mem() const override { return new ConoptMemory(*this); }
+    int init_mem(void* mem) const override;
+    void free_mem(void* mem) const override;
+    void set_work(void* mem, const double**& arg, double**& res,
+                  casadi_int*& iw, double*& w) const override;
+    int solve(void* mem) const override;
+    Dict get_stats(void* mem) const override;
+
+    // Sparsities for the problem components
+    Sparsity gradf_sp_;
+    Sparsity jacg_sp_;
+    Sparsity hesslag_sp_;
+    bool exact_hessian_;
+    Dict opts_; // CONOPT specific options
+
+    // Combined CCS tracking arrays for CONOPT (Objective + Constraints)
+    std::vector<int> jac_colsta_;
+    std::vector<int> jac_rowno_;
+    std::vector<int> jac_nlflag_;
+
+    // Serialization and Deserialization
+    void serialize_body(SerializingStream &s) const override;
+    static ProtoFunction* deserialize(DeserializingStream& s) { return new ConoptInterface(s); }
+
+    // CONOPT Mandatory Callbacks
+    static int COI_CALLCONV cb_read_matrix(double LOWER[], double CURR[], double UPPER[], int VSTA[], int TYPEX[], double RHS[], int ESTA[], int COLSTA[], int ROWNO[], double VALUE[], int NLFLAG[], int NUMVAR, int NUMCON, int NUMNZ, void* USRMEM);
+    static int COI_CALLCONV cb_fdevalini(const double X[], const int ROWLIST[], int MODE, int LISTSIZE, int NUMTHREAD, int IGNERR, int* ERRCNT, int NUMVAR, void* USRMEM);
+    static int COI_CALLCONV cb_fd_eval(const double X[], double* G, double JAC[], int ROWNO, const int JACNUM[], int MODE, int IGNERR, int* ERRCNT, int NUMVAR, int NUMJAC, int THREAD, void* USRMEM);
+    static int COI_CALLCONV cb_fdevalend(int IGNERR, int* ERRCNT, void* USRMEM);
+    static int COI_CALLCONV cb_status(int MODSTA, int SOLSTA, int ITER, double OBJVAL, void* USRMEM);
+    static int COI_CALLCONV cb_solution(const double XVAL[], const double XMAR[], const int XBAS[], const int XSTA[], const double YVAL[], const double YMAR[], const int YBAS[], const int YSTA[], int NUMVAR, int NUMCON, void* USRMEM);
+
+    // Logging and Messages
+    static int COI_CALLCONV cb_message(int SMSG, int DMSG, int NMSG, char* MSGV[], void* USRMEM);
+    static int COI_CALLCONV cb_errmsg(int ROWNO, int COLNO, int POSNO, const char* MSG, void* USRMEM);
+
+    // Options and Progress
+    static int COI_CALLCONV cb_option(int NCALL, double* RVAL, int* IVAL, int* LVAL, char* NAME, void* USRMEM);
+    static int COI_CALLCONV cb_progress(int LEN_INT, const int INTX[], int LEN_RL, const double RL[], const double X[], void* USRMEM);
+
+    // CONOPT 2nd Order Callbacks
+    static int COI_CALLCONV cb_2dlagrsize(int* NODRV, int NUMVAR, int NUMCON, int* NHESS, int MAXHESS, void* USRMEM);
+    static int COI_CALLCONV cb_2dlagrstr(int HSRW[], int HSCL[], int* NODRV, int NUMVAR, int NUMCON, int NHESS, void* USRMEM);
+    static int COI_CALLCONV cb_2dlagrval(const double X[], const double U[], const int HSRW[], const int HSCL[], double HSVL[], int* NODRV, int NUMVAR, int NUMCON, int NHESS, void* USRMEM);
+
+  protected:
+    explicit ConoptInterface(DeserializingStream& s);
+  };
+}
+#endif // CASADI_CONOPT_INTERFACE_HPP

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -32,6 +32,9 @@ namespace casadi {
     std::vector<std::pair<std::string, GenericType>> custom_options;
     size_t current_option_idx;
 
+    // Constant Jacobian values for linear (NLFLAG=0) entries (populated in solve())
+    std::vector<double> const_jac_vals;
+
     // Range-constraint expansion state (recomputed each solve)
     int ng_expanded;
     int numnz_expanded;
@@ -83,6 +86,10 @@ namespace casadi {
     std::vector<int> jacg_rowstart_;
     std::vector<int> jacg_col_;
     std::vector<int> jacg_nzidx_;
+
+    // Per-nonzero linearity flag (0 = constant/linear, 1 = nonlinear), CCS order
+    std::vector<int> jacg_nlflag_;
+    bool has_linear_jac_;
 
     // Serialization and Deserialization
     void serialize_body(SerializingStream &s) const override;

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -114,6 +114,7 @@ namespace casadi {
     Sparsity hesslag_sp_;
     bool exact_hessian_;
     bool warm_start_;
+    bool debug_;
     Dict opts_; // CONOPT specific options
     std::string optfile_; // Path to CONOPT option file (for string-valued CR-cells)
 

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -2,6 +2,7 @@
 #define CASADI_CONOPT_INTERFACE_HPP
 
 #include "casadi/core/nlpsol_impl.hpp"
+#include <casadi/interfaces/conopt/casadi_nlpsol_conopt_export.h>
 #include <conopt.h>
 #include <vector>
 #include <string>
@@ -10,7 +11,7 @@
 namespace casadi {
   class ConoptInterface;
 
-  struct ConoptMemory : public NlpsolMemory {
+  struct CASADI_NLPSOL_CONOPT_EXPORT ConoptMemory : public NlpsolMemory {
     const ConoptInterface& self;
     coiHandle_t cntvect;
 
@@ -18,7 +19,6 @@ namespace casadi {
     int solsta;
     int iter;
     std::string return_status;
-    int success;
 
     // Caching state for the evaluation block
     std::vector<double> cached_x;
@@ -27,13 +27,15 @@ namespace casadi {
     std::vector<double> cached_g;
     std::vector<double> cached_jac_g;
     bool cache_valid;
+    bool nan_encountered;
 
     // Options handling
     std::vector<std::pair<std::string, GenericType>> custom_options;
-    size_t current_option_idx;
 
     // Constant Jacobian values for linear (NLFLAG=0) entries (populated in solve())
     std::vector<double> const_jac_vals;
+    // Constant objective gradient values for linear (NLFLAG=0) entries
+    std::vector<double> gradf_const_vals;
 
     // Range-constraint expansion state (recomputed each solve)
     int ng_expanded;
@@ -48,7 +50,7 @@ namespace casadi {
     ~ConoptMemory();
   };
 
-  class ConoptInterface : public Nlpsol {
+  class CASADI_NLPSOL_CONOPT_EXPORT ConoptInterface : public Nlpsol {
   public:
     explicit ConoptInterface(const std::string& name, const Function& nlp);
     ~ConoptInterface() override;
@@ -82,14 +84,19 @@ namespace casadi {
     // Per-column flag: true if the objective gradient has a nonzero in that column
     std::vector<bool> gradf_col_flag_;
 
-    // Row-indexed (CSR) structure for fast Jacobian scatter in cb_fd_eval
-    std::vector<int> jacg_rowstart_;
-    std::vector<int> jacg_col_;
-    std::vector<int> jacg_nzidx_;
+    // Row-indexed structure for fast Jacobian scatter in cb_fd_eval (nonlinear entries only)
+    std::vector<int> jacg_rowstart_;  // size ng_+1; nonlinear nnz prefix sums per row
+    std::vector<int> jacg_nzidx_;    // CCS indices of nonlinear entries, in row-major order
 
     // Per-nonzero linearity flag (0 = constant/linear, 1 = nonlinear), CCS order
     std::vector<int> jacg_nlflag_;
     bool has_linear_jac_;
+
+    // Objective gradient linearity: flag per nonzero of gradf_sp_
+    std::vector<int> gradf_nlflag_;
+    bool has_linear_gradf_;
+    // Maps variable index → nonzero index in gradf_sp_ (-1 if absent)
+    std::vector<casadi_int> gradf_col_to_nz_;
 
     // Serialization and Deserialization
     void serialize_body(SerializingStream &s) const override;

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -181,7 +181,6 @@ namespace casadi {
     static int COI_CALLCONV cb_progress(int LEN_INT, const int INTX[], int LEN_RL, const double RL[], const double X[], void* USRMEM);
 
     // CONOPT 2nd Order Callbacks
-    static int COI_CALLCONV cb_2dlagrsize(int* NODRV, int NUMVAR, int NUMCON, int* NHESS, int MAXHESS, void* USRMEM);
     static int COI_CALLCONV cb_2dlagrstr(int HSRW[], int HSCL[], int* NODRV, int NUMVAR, int NUMCON, int NHESS, void* USRMEM);
     static int COI_CALLCONV cb_2dlagrval(const double X[], const double U[], const int HSRW[], const int HSCL[], double HSVL[], int* NODRV, int NUMVAR, int NUMCON, int NHESS, void* USRMEM);
 

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -17,7 +17,7 @@ namespace casadi {
     int modsta;
     int solsta;
     int iter;
-    const char* return_status;
+    std::string return_status;
     int success;
 
     // Caching state for the evaluation block
@@ -31,6 +31,15 @@ namespace casadi {
     // Options handling
     std::vector<std::pair<std::string, GenericType>> custom_options;
     size_t current_option_idx;
+
+    // Range-constraint expansion state (recomputed each solve)
+    int ng_expanded;
+    int numnz_expanded;
+    std::vector<int> conopt_to_casadi;   // CONOPT constraint row (0-indexed) → CasADi index
+    std::vector<int> casadi_to_conopt_lb_row;  // CasADi index → CONOPT row for lb (or only) side
+    std::vector<int> casadi_to_conopt_ub_row;  // CasADi index → CONOPT row for ub side (range only); -1 otherwise
+    std::vector<int> conopt_type;        // CONOPT TYPE for each expanded row
+    std::vector<double> conopt_rhs;      // CONOPT RHS for each expanded row
 
     ConoptMemory(const ConoptInterface& interface);
     ~ConoptMemory();
@@ -67,10 +76,13 @@ namespace casadi {
     bool exact_hessian_;
     Dict opts_; // CONOPT specific options
 
-    // Combined CCS tracking arrays for CONOPT (Objective + Constraints)
-    std::vector<int> jac_colsta_;
-    std::vector<int> jac_rowno_;
-    std::vector<int> jac_nlflag_;
+    // Per-column flag: true if the objective gradient has a nonzero in that column
+    std::vector<bool> gradf_col_flag_;
+
+    // Row-indexed (CSR) structure for fast Jacobian scatter in cb_fd_eval
+    std::vector<int> jacg_rowstart_;
+    std::vector<int> jacg_col_;
+    std::vector<int> jacg_nzidx_;
 
     // Serialization and Deserialization
     void serialize_body(SerializingStream &s) const override;

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -34,6 +34,15 @@ namespace casadi {
     Free         = 3   // a free row
   };
 
+  // CONOPT's IniStat=2 basis-status convention, shared by VSTA (variables) and
+  // ESTA (constraint slacks) in the ReadMatrix callback.
+  enum class ConoptBasisStatus {
+    AtLower   = 0,  // initialized at lower bound
+    AtUpper   = 1,  // initialized at upper bound
+    Basic     = 2,  // initialized basic
+    SuperBasic = 3  // initialized superbasic
+  };
+
   enum class ConoptSolverStatus {
     Unset              = 0,
     NormalCompletion   = 1,

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -4,6 +4,7 @@
 #include "casadi/core/nlpsol_impl.hpp"
 #include <casadi/interfaces/conopt/casadi_nlpsol_conopt_export.h>
 #include <conopt.h>
+#include <atomic>
 #include <vector>
 #include <string>
 #include <utility>
@@ -54,7 +55,8 @@ namespace casadi {
     std::vector<double> cached_grad_f;
     std::vector<double> cached_g;
     std::vector<double> cached_jac_g;
-    bool cache_valid;
+    std::atomic<bool> cache_valid{false};
+    std::atomic<bool> cache_valid_jac{false};  // true only when cached_jac_g was computed
     bool nan_encountered;
 
     // Options handling
@@ -68,6 +70,7 @@ namespace casadi {
     // Range-constraint expansion state (recomputed each solve)
     int ng_expanded;
     int numnz_expanded;
+    std::vector<int> row_nnz;            // nnz per CasADi row, persistent across solves
     std::vector<int> conopt_to_casadi;   // CONOPT constraint row (0-indexed) → CasADi index
     std::vector<int> casadi_to_conopt_lb_row;  // CasADi index → CONOPT row for lb (or only) side
     std::vector<int> casadi_to_conopt_ub_row;  // CasADi index → CONOPT row for ub side (range only); -1 otherwise

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -84,6 +84,9 @@ namespace casadi {
     std::vector<double> const_jac_vals;
     // Constant objective gradient values for linear (NLFLAG=0) entries
     std::vector<double> gradf_const_vals;
+    // Scratch buffer for the linear part of G at x0 per row (only used when
+    // has_linear_jac_); persistent to avoid a per-solve heap allocation.
+    std::vector<double> linear_at_x0;
 
     // Range-constraint expansion state (recomputed each solve)
     int ng_expanded;

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -74,6 +74,9 @@ namespace casadi {
     std::vector<int> conopt_type;        // CONOPT TYPE for each expanded row
     std::vector<double> conopt_rhs;      // CONOPT RHS for each expanded row
 
+    // Multiplier buffer for Hessian callback (avoids per-call allocation)
+    std::vector<double> hess_lam_g_;
+
     ConoptMemory(const ConoptInterface& interface);
     ~ConoptMemory();
   };
@@ -107,7 +110,9 @@ namespace casadi {
     Sparsity jacg_sp_;
     Sparsity hesslag_sp_;
     bool exact_hessian_;
+    bool warm_start_;
     Dict opts_; // CONOPT specific options
+    std::string optfile_; // Path to CONOPT option file (for string-valued CR-cells)
 
     // Per-column flag: true if the objective gradient has a nonzero in that column
     std::vector<bool> gradf_col_flag_;
@@ -115,6 +120,7 @@ namespace casadi {
     // Row-indexed structure for fast Jacobian scatter in cb_fd_eval (nonlinear entries only)
     std::vector<int> jacg_rowstart_;  // size ng_+1; nonlinear nnz prefix sums per row
     std::vector<int> jacg_nzidx_;    // CCS indices of nonlinear entries, in row-major order
+    std::vector<int> jacg_col_;      // column (variable) index of each entry in jacg_nzidx_
 
     // Per-nonzero linearity flag (0 = constant/linear, 1 = nonlinear), CCS order
     std::vector<int> jacg_nlflag_;

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -11,12 +11,40 @@
 namespace casadi {
   class ConoptInterface;
 
+  enum class ConoptModelStatus {
+    Unset              = 0,
+    Optimal            = 1,
+    LocallyOptimal     = 2,
+    Unbounded          = 3,
+    Infeasible         = 4,
+    LocallyInfeasible  = 5,
+    IntermediateInfeas = 6,
+    IntermediateNonOpt = 7,
+    UnknownError       = 12,
+    ErrorNoSolution    = 13
+  };
+
+  enum class ConoptSolverStatus {
+    Unset              = 0,
+    NormalCompletion   = 1,
+    IterationLimit     = 2,
+    TimeLimit          = 3,
+    TerminatedBySolver = 4,
+    EvalErrorLimit     = 5,
+    UserInterrupt      = 8,
+    SetupFailure       = 9,
+    MajorSolverError   = 10,
+    MajorSolverErrorFeas = 11,
+    SystemError        = 13,
+    QuickModeTermination = 15
+  };
+
   struct CASADI_NLPSOL_CONOPT_EXPORT ConoptMemory : public NlpsolMemory {
     const ConoptInterface& self;
     coiHandle_t cntvect;
 
-    int modsta;
-    int solsta;
+    ConoptModelStatus modsta;
+    ConoptSolverStatus solsta;
     int iter;
     std::string return_status;
 

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -1,3 +1,27 @@
+/*
+ *    This file is part of CasADi.
+ *
+ *    CasADi -- A symbolic framework for dynamic optimization.
+ *    Copyright (C) 2010-2023 Joel Andersson, Joris Gillis, Moritz Diehl,
+ *                            KU Leuven. All rights reserved.
+ *    Copyright (C) 2011-2014 Greg Horn
+ *
+ *    CasADi is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation; either
+ *    version 3 of the License, or (at your option) any later version.
+ *
+ *    CasADi is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public
+ *    License along with CasADi; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
 #ifndef CASADI_CONOPT_INTERFACE_HPP
 #define CASADI_CONOPT_INTERFACE_HPP
 
@@ -94,7 +118,8 @@ namespace casadi {
     std::vector<int> row_nnz;            // nnz per CasADi row, persistent across solves
     std::vector<int> conopt_to_casadi;   // CONOPT constraint row (0-indexed) → CasADi index
     std::vector<int> casadi_to_conopt_lb_row;  // CasADi index → CONOPT row for lb (or only) side
-    std::vector<int> casadi_to_conopt_ub_row;  // CasADi index → CONOPT row for ub side (range only); -1 otherwise
+    // CasADi index -> CONOPT row for ub side (range only); -1 otherwise
+    std::vector<int> casadi_to_conopt_ub_row;
     std::vector<ConoptRowType> conopt_type;  // CONOPT TYPE for each expanded row
     std::vector<double> conopt_rhs;      // CONOPT RHS for each expanded row
 
@@ -135,6 +160,10 @@ namespace casadi {
     int solve(void* mem) const override;
     Dict get_stats(void* mem) const override;
 
+    // Grows conopt_to_casadi/conopt_type/conopt_rhs (which always stay the same
+    // size as each other) when they are full, used by solve()'s row-expansion loop.
+    void ensure_row_capacity(ConoptMemory* m, casadi_int remaining_rows) const;
+
     // Sparsities for the problem components
     Sparsity gradf_sp_;
     Sparsity jacg_sp_;
@@ -168,27 +197,49 @@ namespace casadi {
     static ProtoFunction* deserialize(DeserializingStream& s) { return new ConoptInterface(s); }
 
     // CONOPT Mandatory Callbacks
-    static int COI_CALLCONV cb_read_matrix(double LOWER[], double CURR[], double UPPER[], int VSTA[], int TYPEX[], double RHS[], int ESTA[], int COLSTA[], int ROWNO[], double VALUE[], int NLFLAG[], int NUMVAR, int NUMCON, int NUMNZ, void* USRMEM);
-    static int COI_CALLCONV cb_fdevalini(const double X[], const int ROWLIST[], int MODE, int LISTSIZE, int NUMTHREAD, int IGNERR, int* ERRCNT, int NUMVAR, void* USRMEM);
-    static int COI_CALLCONV cb_fd_eval(const double X[], double* G, double JAC[], int ROWNO, const int JACNUM[], int MODE, int IGNERR, int* ERRCNT, int NUMVAR, int NUMJAC, int THREAD, void* USRMEM);
+    static int COI_CALLCONV cb_read_matrix(double LOWER[], double CURR[], double UPPER[],
+                                            int VSTA[], int TYPEX[], double RHS[],
+                                            int ESTA[], int COLSTA[], int ROWNO[],
+                                            double VALUE[], int NLFLAG[], int NUMVAR,
+                                            int NUMCON, int NUMNZ, void* USRMEM);
+    static int COI_CALLCONV cb_fdevalini(const double X[], const int ROWLIST[], int MODE,
+                                          int LISTSIZE, int NUMTHREAD, int IGNERR,
+                                          int* ERRCNT, int NUMVAR, void* USRMEM);
+    static int COI_CALLCONV cb_fd_eval(const double X[], double* G, double JAC[],
+                                        int ROWNO, const int JACNUM[], int MODE, int IGNERR,
+                                        int* ERRCNT, int NUMVAR, int NUMJAC, int THREAD,
+                                        void* USRMEM);
     static int COI_CALLCONV cb_fdevalend(int IGNERR, int* ERRCNT, void* USRMEM);
-    static int COI_CALLCONV cb_status(int MODSTA, int SOLSTA, int ITER, double OBJVAL, void* USRMEM);
-    static int COI_CALLCONV cb_solution(const double XVAL[], const double XMAR[], const int XBAS[], const int XSTA[], const double YVAL[], const double YMAR[], const int YBAS[], const int YSTA[], int NUMVAR, int NUMCON, void* USRMEM);
+    static int COI_CALLCONV cb_status(int MODSTA, int SOLSTA, int ITER, double OBJVAL,
+                                       void* USRMEM);
+    static int COI_CALLCONV cb_solution(const double XVAL[], const double XMAR[],
+                                         const int XBAS[], const int XSTA[],
+                                         const double YVAL[], const double YMAR[],
+                                         const int YBAS[], const int YSTA[],
+                                         int NUMVAR, int NUMCON, void* USRMEM);
 
     // Logging and Messages
-    static int COI_CALLCONV cb_message(int SMSG, int DMSG, int NMSG, char* MSGV[], void* USRMEM);
-    static int COI_CALLCONV cb_errmsg(int ROWNO, int COLNO, int POSNO, const char* MSG, void* USRMEM);
+    static int COI_CALLCONV cb_message(int SMSG, int DMSG, int NMSG, char* MSGV[],
+                                        void* USRMEM);
+    static int COI_CALLCONV cb_errmsg(int ROWNO, int COLNO, int POSNO, const char* MSG,
+                                       void* USRMEM);
 
     // Options and Progress
-    static int COI_CALLCONV cb_option(int NCALL, double* RVAL, int* IVAL, int* LVAL, char* NAME, void* USRMEM);
-    static int COI_CALLCONV cb_progress(int LEN_INT, const int INTX[], int LEN_RL, const double RL[], const double X[], void* USRMEM);
+    static int COI_CALLCONV cb_option(int NCALL, double* RVAL, int* IVAL, int* LVAL,
+                                       char* NAME, void* USRMEM);
+    static int COI_CALLCONV cb_progress(int LEN_INT, const int INTX[], int LEN_RL,
+                                         const double RL[], const double X[], void* USRMEM);
 
     // CONOPT 2nd Order Callbacks
-    static int COI_CALLCONV cb_2dlagrstr(int HSRW[], int HSCL[], int* NODRV, int NUMVAR, int NUMCON, int NHESS, void* USRMEM);
-    static int COI_CALLCONV cb_2dlagrval(const double X[], const double U[], const int HSRW[], const int HSCL[], double HSVL[], int* NODRV, int NUMVAR, int NUMCON, int NHESS, void* USRMEM);
+    static int COI_CALLCONV cb_2dlagrstr(int HSRW[], int HSCL[], int* NODRV, int NUMVAR,
+                                          int NUMCON, int NHESS, void* USRMEM);
+    static int COI_CALLCONV cb_2dlagrval(const double X[], const double U[],
+                                          const int HSRW[], const int HSCL[], double HSVL[],
+                                          int* NODRV, int NUMVAR, int NUMCON, int NHESS,
+                                          void* USRMEM);
 
   protected:
     explicit ConoptInterface(DeserializingStream& s);
   };
-}
+}  // namespace casadi
 #endif // CASADI_CONOPT_INTERFACE_HPP

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -25,6 +25,15 @@ namespace casadi {
     ErrorNoSolution    = 13
   };
 
+  // CONOPT's TYPE row-type convention (used for both TYPEX[] passed to CONOPT
+  // and the interface's own conopt_type bookkeeping).
+  enum class ConoptRowType {
+    Equality     = 0,  // an equality constraint
+    GreaterEqual = 1,  // a greater than or equal constraint
+    LessEqual    = 2,  // a less than or equal constraint
+    Free         = 3   // a free row
+  };
+
   enum class ConoptSolverStatus {
     Unset              = 0,
     NormalCompletion   = 1,
@@ -74,7 +83,7 @@ namespace casadi {
     std::vector<int> conopt_to_casadi;   // CONOPT constraint row (0-indexed) → CasADi index
     std::vector<int> casadi_to_conopt_lb_row;  // CasADi index → CONOPT row for lb (or only) side
     std::vector<int> casadi_to_conopt_ub_row;  // CasADi index → CONOPT row for ub side (range only); -1 otherwise
-    std::vector<int> conopt_type;        // CONOPT TYPE for each expanded row
+    std::vector<ConoptRowType> conopt_type;  // CONOPT TYPE for each expanded row
     std::vector<double> conopt_rhs;      // CONOPT RHS for each expanded row
 
     // Multiplier buffer for Hessian callback (avoids per-call allocation)

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -80,6 +80,9 @@ namespace casadi {
     // Multiplier buffer for Hessian callback (avoids per-call allocation)
     std::vector<double> hess_lam_g_;
 
+    // Stored constant objective value when the interface is in feasibility mode
+    double obj_const_;
+
     ConoptMemory(const ConoptInterface& interface);
     ~ConoptMemory();
   };

--- a/casadi/interfaces/conopt/conopt_interface.hpp
+++ b/casadi/interfaces/conopt/conopt_interface.hpp
@@ -123,6 +123,9 @@ namespace casadi {
     static const Options options_;
     const Options& get_options() const override { return options_; }
 
+    /// A documentation string
+    static const std::string meta_doc;
+
     void init(const Dict& opts) override;
     void* alloc_mem() const override { return new ConoptMemory(*this); }
     int init_mem(void* mem) const override;

--- a/casadi/interfaces/conopt/conopt_interface_meta.cpp
+++ b/casadi/interfaces/conopt/conopt_interface_meta.cpp
@@ -1,0 +1,61 @@
+/*
+ *    This file is part of CasADi.
+ *
+ *    CasADi -- A symbolic framework for dynamic optimization.
+ *    Copyright (C) 2010-2023 Joel Andersson, Joris Gillis, Moritz Diehl,
+ *                            KU Leuven. All rights reserved.
+ *    Copyright (C) 2011-2014 Greg Horn
+ *
+ *    CasADi is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation; either
+ *    version 3 of the License, or (at your option) any later version.
+ *
+ *    CasADi is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public
+ *    License along with CasADi; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+
+      #include "conopt_interface.hpp"
+      #include <string>
+
+      const std::string casadi::ConoptInterface::meta_doc=
+      "\n"
+"\n"
+"\n"
+"CONOPT interface\n"
+"\n"
+"\n"
+">List of available options\n"
+"\n"
+"+---------------+-----------+-----------------------------------+\n"
+"|      Id       |   Type    |            Description            |\n"
+"+===============+===========+===================================+\n"
+"| conopt        | OT_DICT   | Options to be passed to CONOPT    |\n"
+"+---------------+-----------+-----------------------------------+\n"
+"| debug         | OT_BOOL   | Print debug output: constraint    |\n"
+"|               |           | values at each FDEval, solution   |\n"
+"|               |           | vector, and option echo           |\n"
+"+---------------+-----------+-----------------------------------+\n"
+"| exact_hessian | OT_BOOL   | Provide exact Hessian to CONOPT   |\n"
+"+---------------+-----------+-----------------------------------+\n"
+"| optfile       | OT_STRING | Path to a CONOPT option file (for |\n"
+"|               |           | string-valued CR-cells such as    |\n"
+"|               |           | Algorithm)                        |\n"
+"+---------------+-----------+-----------------------------------+\n"
+"| warm_start    | OT_BOOL   | Warm-start CONOPT using           |\n"
+"|               |           | multipliers from a prior solve to |\n"
+"|               |           | infer basis status (IniStat=2)    |\n"
+"+---------------+-----------+-----------------------------------+\n"
+"\n"
+"\n"
+"\n"
+"\n"
+;

--- a/cmake/FindCONOPT.cmake
+++ b/cmake/FindCONOPT.cmake
@@ -1,0 +1,52 @@
+# Prefer explicit user-provided root (case-insensitive, keep both)
+if(NOT DEFINED CONOPT_ROOT AND DEFINED conopt_ROOT)
+  set(CONOPT_ROOT "${conopt_ROOT}" CACHE PATH "Root path to CONOPT installation" FORCE)
+endif()
+
+if(NOT DEFINED CONOPT_ROOT)
+  set(CONOPT_ROOT $ENV{CONOPT} CACHE PATH "Root path to CONOPT installation (from CONOPT env)" )
+endif()
+
+# Find the include directory containing conopt.h
+find_path(CONOPT_INCLUDE_DIR
+  NAMES conopt.h
+  HINTS "${CONOPT_ROOT}/include" "${CONOPT_ROOT}" "${CMAKE_PREFIX_PATH}/include"
+  PATH_SUFFIXES ""
+  DOC "CONOPT C API include directory")
+
+if(CONOPT_INCLUDE_DIR)
+   message(STATUS "Found CONOPT include dir: ${CONOPT_INCLUDE_DIR}")
+else()
+   message(STATUS "Could not find CONOPT include dir")
+endif()
+
+# Find the CONOPT library
+find_library(CONOPT_LIBRARY
+  NAMES conopt libconopt
+  HINTS "${CONOPT_ROOT}/lib" "${CONOPT_ROOT}/lib64" "${CONOPT_ROOT}" "${CMAKE_PREFIX_PATH}/lib"
+  DOC "CONOPT library")
+
+if(CONOPT_LIBRARY)
+  set(CONOPT_LIBRARIES "${CONOPT_LIBRARY}")
+  message(STATUS "Found CONOPT libraries: ${CONOPT_LIBRARIES}")
+else()
+  message(STATUS "Could not find CONOPT library")
+endif()
+
+# Handle standard arguments and set CONOPT_FOUND
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CONOPT DEFAULT_MSG CONOPT_LIBRARIES CONOPT_INCLUDE_DIR)
+
+# Create the imported target so casadi_plugin_link_libraries(Nlpsol conopt conopt::conopt) works
+if(CONOPT_FOUND)
+  if(NOT TARGET conopt::conopt)
+    add_library(conopt::conopt UNKNOWN IMPORTED)
+    set_target_properties(conopt::conopt PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${CONOPT_INCLUDE_DIR}"
+      IMPORTED_LOCATION "${CONOPT_LIBRARIES}"
+    )
+  endif()
+endif()
+
+# Hide these variables from the standard CMake GUI to keep it clean
+mark_as_advanced(CONOPT_ROOT CONOPT_INCLUDE_DIR CONOPT_LIBRARY)

--- a/cmake/FindCONOPT.cmake
+++ b/cmake/FindCONOPT.cmake
@@ -1,16 +1,16 @@
 # Prefer explicit user-provided root (case-insensitive, keep both)
-if(NOT DEFINED CONOPT_ROOT AND DEFINED conopt_ROOT)
-  set(CONOPT_ROOT "${conopt_ROOT}" CACHE PATH "Root path to CONOPT installation" FORCE)
+if(NOT DEFINED CONOPT_DIR AND DEFINED conopt_DIR)
+  set(CONOPT_DIR "${conopt_DIR}" CACHE PATH "Root path to CONOPT installation" FORCE)
 endif()
 
-if(NOT DEFINED CONOPT_ROOT)
-  set(CONOPT_ROOT $ENV{CONOPT} CACHE PATH "Root path to CONOPT installation (from CONOPT env)" )
+if(NOT DEFINED CONOPT_DIR)
+  set(CONOPT_DIR $ENV{CONOPT} CACHE PATH "Root path to CONOPT installation (from CONOPT env)" )
 endif()
 
 # Find the include directory containing conopt.h
 find_path(CONOPT_INCLUDE_DIR
   NAMES conopt.h
-  HINTS "${CONOPT_ROOT}/include" "${CONOPT_ROOT}" "${CMAKE_PREFIX_PATH}/include"
+  HINTS "${CONOPT_DIR}/include" "${CONOPT_DIR}" "${CMAKE_PREFIX_PATH}/include"
   PATH_SUFFIXES ""
   DOC "CONOPT C API include directory")
 
@@ -23,7 +23,7 @@ endif()
 # Find the CONOPT library
 find_library(CONOPT_LIBRARY
   NAMES conopt libconopt
-  HINTS "${CONOPT_ROOT}/lib" "${CONOPT_ROOT}/lib64" "${CONOPT_ROOT}" "${CMAKE_PREFIX_PATH}/lib"
+  HINTS "${CONOPT_DIR}/lib" "${CONOPT_DIR}/lib64" "${CONOPT_DIR}" "${CMAKE_PREFIX_PATH}/lib"
   DOC "CONOPT library")
 
 if(CONOPT_LIBRARY)
@@ -49,4 +49,4 @@ if(CONOPT_FOUND)
 endif()
 
 # Hide these variables from the standard CMake GUI to keep it clean
-mark_as_advanced(CONOPT_ROOT CONOPT_INCLUDE_DIR CONOPT_LIBRARY)
+mark_as_advanced(CONOPT_DIR CONOPT_INCLUDE_DIR CONOPT_LIBRARY)

--- a/test/python/nlp.py
+++ b/test/python/nlp.py
@@ -109,6 +109,9 @@ libmad_codegen = {"extralibs": ["Mad"], "std": "c99",
 if "SKIP_MADNLP_TESTS" not in os.environ and ca.has_nlpsol("madnlp"):
   solvers.append(("madnlp",{"madnlp": {}},{"codegen": libmad_codegen,"discrete":False}))
 
+if "SKIP_CONOPT_TESTS" not in os.environ and ca.has_nlpsol("conopt"):
+   solvers.append(("conopt",{"conopt":{"Tol_Feas_Min":1e-9, "Tol_Optimality":1e-9}},{"codegen": False,"discrete":False}))
+
 print(solvers)
 
 class NLPtests(casadiTestCase):


### PR DESCRIPTION
Adds a new Nlpsol plugin wrapping CONOPT via its C API (casadi/interfaces/conopt/), supporting first- and second-order (exact Hessian) solves.

## Features
- Detects constant/linear Jacobian and objective-gradient entries via second-order sparsity to avoid unnecessary FDEval calls and correctly absorb constant terms into the RHS.
- Splits range constraints (lbg ≤ g(x) ≤ ubg, both finite) into two rows since CONOPT doesn't support ranged constraints natively.
- Supports warm-starting from a prior solve's multipliers (warm_start option, IniStat=2), CONOPT option passthrough (conopt dict + optfile for string-valued options), and a debug option for verbose per-evaluation tracing.
- Handles the CONOPT-specific quirk where a structurally constant objective never gets an FDEval call (switches to feasibility mode and restores the true value afterward).